### PR TITLE
Removes developer documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -59,25 +59,6 @@
             ]
           }
         ]
-      },
-      {
-        "tab": "Developer Docs",
-        "groups": [
-          {
-            "group": "API Documentation",
-            "pages": [
-              "api-reference/introduction"
-            ]
-          },
-          {
-            "group": "Endpoint Examples",
-            "pages": [
-              "api-reference/endpoint/get",
-              "api-reference/endpoint/create",
-              "api-reference/endpoint/delete"
-            ]
-          }
-        ]
       }
     ],
     "global": {


### PR DESCRIPTION
Removes the separate "Developer Docs" tab.

This simplifies the documentation structure and streamlines the user experience by consolidating all documentation under a single tab.

Dev docs to return post June 1st
