### PR TITLE
Adds legacy documentation landing page for v2 connectors

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -45,7 +45,6 @@
                   "3d-viewer/federation",
                   "3d-viewer/exploration",
                   "3d-viewer/presentation"
-                  
                 ]
               },
               "3d-viewer/sharing"
@@ -156,6 +155,7 @@
           {
             "group": "Legacy Connectors",
             "pages": [
+              "legacy/user/overview",
               {
                 "group": "Revit",
                 "pages": [

--- a/legacy/user/overview.mdx
+++ b/legacy/user/overview.mdx
@@ -1,0 +1,9 @@
+---
+tag: Legacy
+---
+
+import LegacyWarning from '/snippets/legacy-warning.mdx';
+
+<LegacyWarning connector="documentation previously found in speckle.guide for each" />
+
+This section contains documentation for our legacy v2 connectors. While these connectors are no longer actively developed, we’re keeping these guides available here for your convenience.


### PR DESCRIPTION
Introduces an overview section for legacy connectors, providing essential guidance for users.

Removes an empty entry in the documentation structure and ensures that legacy documentation is readily accessible.

Enhances user experience by maintaining documentation for connectors that are no longer actively developed.
