### PR TITLE
Removes outdated Github link from documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -220,11 +220,6 @@
               "anchor": "Youtube",
               "href": "https://www.youtube.com/@SpeckleSystems",
               "icon": "youtube"
-            },
-            {
-              "anchor": "Github",
-              "href": "https://github.com/specklesystems",
-              "icon": "github"
             }
           ]
         },


### PR DESCRIPTION
Eliminates the Github anchor from the documentation to streamline the resources section.

Updates focus on current relevant links to align
with user experience needs.