### PR TITLE
Feat: Add context7 config

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Speckle",
+  "description": "Open source platform that simplifies sharing models, feedback, and insights across all your CAD & BIM tools.",
+  "folders": [
+    "quickstart",
+    "workspaces",
+    "3d-viewer",
+    "connectors",
+    "workflows",
+    "developers",
+    "migration"
+  ],
+  "excludeFolders": ["images", "legacy/user", "static", "logo", "snippets"],
+  "excludeFiles": [
+    "package.json",
+    "package-lock.json",
+    "README.md",
+    "docs.json",
+    "style.css",
+    "download_images.sh",
+    "rename_images.sh"
+  ]
+}


### PR DESCRIPTION
[Context7](https://context7.com/) is an MCP that helps LLMs/AI code editors have up-to-date docs. I was trying out some new workflows, but currently it's still using our old docs which causes agents to rely on outdated docs. I updated it on their site, but having a config gives us a bit more control over what it parses 