### PR TITLE
chore(grasshopper): modifies docs to better explain passthrough nodes

### DIFF
--- a/connectors/grasshopper/grasshopper-objects.mdx
+++ b/connectors/grasshopper/grasshopper-objects.mdx
@@ -25,7 +25,7 @@ Use the **Speckle Geometry** passthrough node for more advanced control of your 
 </Frame>
 
 **Inputs**
-1. Add a **Speckle Geometry** input only if you want to inspect or modify an existing Speckle Geometry.
+1. Add a **Speckle Geometry** input if you want to inspect or modify an existing Speckle Geometry, or are [casting a Model object](/connectors/grasshopper/grasshopper-objects#baking-and-casting-speckle-geometry) to assign all attributes during creation.
 2. Add a **Geometry** input to create a new Speckle Geometry or modify the geometry of (1).
 3. Add an optional **Name** input to set or change the name of the geometry.
 4. Add an optional **Properties** input to set or change the properties of the geometry.
@@ -79,7 +79,7 @@ Use the **Speckle Block Definition** passthrough node for more advanced control 
 </Frame>
 
 **Inputs**
-1. Add a **Speckle Block Definition** input only if you want to inspect or modify an existing Speckle Block Definition.
+1. Add a **Speckle Block Definition** input only if you want to inspect or modify an existing Speckle Block Definition, or are [casting a Model definition](/connectors/grasshopper/grasshopper-objects#baking-and-casting-speckle-blocks) to assign all attributes during creation.
 2. Add a **Name** input to set or change the name of the block definition.
 3. Add a **Geometries** input list of Speckle Geometry to set or change the definition geometries.
 
@@ -95,7 +95,7 @@ Use the **Speckle Block Instance** passthrough node for more advanced control of
 </Frame>
 
 **Inputs**
-1. Add a **Speckle Block Instance** input only if you want to inspect or modify an existing Speckle Block Instance.
+1. Add a **Speckle Block Instance** input only if you want to inspect or modify an existing Speckle Block Instance, or are [casting a Model instance](/connectors/grasshopper/grasshopper-objects#baking-and-casting-speckle-blocks) to assign all attributes during creation.
 2. Add a **Definition** input to set or change the block definition of the instance.
 3. Add an optional **Transform** input to set or change the transform of the instance. Default is the identity transform.
 4. Add an optional **Name** input to set or change the name of the instance.
@@ -157,7 +157,7 @@ Since Speckle Data Objects can contain multiple geometries, use the Speckle Geom
 </Frame>
 
 **Inputs**
-1. Add a **Speckle Data Object** input only if you want to inspect or modify an existing Speckle Data Object.
+1. Add a **Speckle Data Object** input only if you want to inspect or modify an existing Speckle Data Object, or are [casting a Model object](/connectors/grasshopper/grasshopper-objects#baking-and-casting-speckle-data-objects) to assign all attributes during creation.
 2. Add a **Geometries** input list of Speckle Geometry to set or change the geometries of the Data Object.
 3. Add an optional **Name** input to set or change the name of the geometry.
 4. Add an optional **Properties** input to set or change the properties of the geometry.


### PR DESCRIPTION
Changes came from bug reports from Jonathan R  because he didn't understand how to use passthrough nodes to preserve model object attributes on cast