### PR TITLE
Adds Assets connectors standalone page

### DIFF
--- a/connectors/grasshopper/grasshopper.mdx
+++ b/connectors/grasshopper/grasshopper.mdx
@@ -46,11 +46,19 @@ import LoadFaq from "/snippets/connectors/load-faq.mdx";
     <SetupFaq app="Grasshopper" />
 </AccordionGroup>
 
+## Getting Started
+
+<Tip>
+  **Template File**: Download our [Grasshopper template file](/static/gh/assets) to get started quickly with common Speckle nodes and workflows.
+</Tip>
+
 ## Publishing a Model
 
 <Tip>
-  Full documentation of all Grasshopper nodes and sample scripts is installed with your connector.
+  **Sample Files**: Full documentation of all Grasshopper nodes and sample scripts is installed with your connector.
   Navigate to **File** > **Special Folders** > **Components Folder** > **Speckle Sample Files** in Grasshopper to find them.
+  
+  **Template File**: For a quick start, download our [Grasshopper template file](/static/gh/assets) with common Speckle nodes and workflows.
 </Tip>
 
 <Steps>
@@ -116,8 +124,10 @@ import LoadFaq from "/snippets/connectors/load-faq.mdx";
 ## Loading a Model
 
 <Tip>
-  Full documentation of all Grasshopper nodes and sample scripts is installed with your connector.
+  **Sample Files**: Full documentation of all Grasshopper nodes and sample scripts is installed with your connector.
   Navigate to **File** > **Special Folders** > **Components Folder** > **Speckle Sample Files** in Grasshopper to find them.
+  
+  **Template File**: For a quick start, download our [Grasshopper template file](/static/gh/assets) with common Speckle nodes and workflows.
 </Tip>
 
 <Steps>

--- a/docs.json
+++ b/docs.json
@@ -89,6 +89,7 @@
                 "pages": [
                   "connectors/overview",
                   "connectors/installation",
+                  "static/gh/assets",
                   "connectors/revit",
                   "connectors/rhino",
                   {

--- a/static/gh/assets.mdx
+++ b/static/gh/assets.mdx
@@ -1,0 +1,21 @@
+---
+title: "Connector Assets & Templates"
+sidebarTitle: "Assets & Templates"
+description: "Download templates, sample files, and resources for Speckle connectors"
+---
+
+## Grasshopper
+
+### Template Files
+- [Grasshopper Template File](./speckle-grasshopper-template.gh) - Basic template with common Speckle nodes and workflows
+
+### Sample Files
+Sample files are installed with your Grasshopper connector. Navigate to **File** > **Special Folders** > **Components Folder** > **Speckle Sample Files** in Grasshopper to find them.
+
+
+
+---
+
+## Contributing
+
+If you have templates, sample files, or other resources that would be helpful for the Speckle community, please share them in our [community forum](https://speckle.community/).


### PR DESCRIPTION
Includes instructions on accessing sample files.

Provides documentation for Grasshopper assets, enabling users to quickly start and improve their initial experience.
