### PR TITLE
Adds 'noindex' flag to legacy documentation files

### DIFF
--- a/legacy/user/archicad.mdx
+++ b/legacy/user/archicad.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'ArchiCAD'
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx';

--- a/legacy/user/autocadcivil.mdx
+++ b/legacy/user/autocadcivil.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'AutoCAD and Civil 3D'
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/bentley.mdx
+++ b/legacy/user/bentley.mdx
@@ -1,6 +1,7 @@
 ---
 sidebarTitle: 'Bentley'
 title: Bentley (MicroStation, OpenRoads, OpenRail, and OpenBuildings)
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/blender.mdx
+++ b/legacy/user/blender.mdx
@@ -1,5 +1,6 @@
 ---
 title: Blender
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx';

--- a/legacy/user/csi.mdx
+++ b/legacy/user/csi.mdx
@@ -1,6 +1,7 @@
 ---
 title: CSI Products (ETABS, CSiBridge, SAP2000, SAFE)
 sidebarTitle: CSI Products
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/dynamo.mdx
+++ b/legacy/user/dynamo.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Dynamo for Revit'
 sidebarTitle: Revit
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/grasshopper.mdx
+++ b/legacy/user/grasshopper.mdx
@@ -1,5 +1,6 @@
 ---
 title: Grasshopper
+noindex: true
 ---
 
 

--- a/legacy/user/manager.mdx
+++ b/legacy/user/manager.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Manager'
 description: 'Install and manage Speckle connectors and accounts'
+noindex: true
 ---
 
 import LegacyManager from '/snippets/legacy-manager.mdx'

--- a/legacy/user/mapping-tool.mdx
+++ b/legacy/user/mapping-tool.mdx
@@ -1,6 +1,7 @@
 ---
 title: Mapping Tool (alpha)
 sidebarTitle: Mapping Tool
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/navisworks.mdx
+++ b/legacy/user/navisworks.mdx
@@ -1,5 +1,6 @@
 ---
 title: Navisworks
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/overview.mdx
+++ b/legacy/user/overview.mdx
@@ -1,5 +1,6 @@
 ---
 tag: Legacy
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx';

--- a/legacy/user/powerbi-visual/basic-usage.mdx
+++ b/legacy/user/powerbi-visual/basic-usage.mdx
@@ -1,6 +1,7 @@
 ---
 title: Using the 3D Viewer Visual
 sidebar_label: Basic Usage
+noindex: true
 ---
 import LegacyWarning from '/snippets/legacy-warning.mdx'
 import LegacyVersions from '/snippets/legacy-versions.mdx'

--- a/legacy/user/powerbi-visual/coloring.mdx
+++ b/legacy/user/powerbi-visual/coloring.mdx
@@ -1,6 +1,7 @@
 ---
 title: Coloring Objects in 3D
 sidebar_label: Coloring
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/powerbi-visual/general-settings.mdx
+++ b/legacy/user/powerbi-visual/general-settings.mdx
@@ -1,6 +1,7 @@
 ---
 title: General Settings
 sidebar_label: General Settings
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/powerbi-visual/introduction.mdx
+++ b/legacy/user/powerbi-visual/introduction.mdx
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/powerbi-visual/object-tooltip.mdx
+++ b/legacy/user/powerbi-visual/object-tooltip.mdx
@@ -1,6 +1,7 @@
 ---
 title: Object Tooltips
 sidebar_label: Object Tooltips
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/powerbi-visual/visual-settings.mdx
+++ b/legacy/user/powerbi-visual/visual-settings.mdx
@@ -1,6 +1,7 @@
 ---
 title: Visual Settings
 sidebar_label: Visual Settings
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/powerbi/accessing-private-streams.mdx
+++ b/legacy/user/powerbi/accessing-private-streams.mdx
@@ -1,3 +1,7 @@
+---
+noindex: true
+---
+
 # Accessing private models
 
 Once you complete the installation and configuration steps, you can receive "public" models from Speckle. To receive your private models, you need to complete authentication. There are two authentication methods:

--- a/legacy/user/powerbi/configuration.mdx
+++ b/legacy/user/powerbi/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/powerbi/introduction.mdx
+++ b/legacy/user/powerbi/introduction.mdx
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/powerbi/uninstallation.mdx
+++ b/legacy/user/powerbi/uninstallation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Uninstallation
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/powerbi/using-powerbi-connector.mdx
+++ b/legacy/user/powerbi/using-powerbi-connector.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using Power BI Connector
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/powerbi/working-with-records.mdx
+++ b/legacy/user/powerbi/working-with-records.mdx
@@ -1,5 +1,6 @@
 ---
 title: Working with Records
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/qgis.mdx
+++ b/legacy/user/qgis.mdx
@@ -1,5 +1,6 @@
 ---
 title: QGIS
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/revit/advanced-settings.mdx
+++ b/legacy/user/revit/advanced-settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: Settings
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/revit/faq.mdx
+++ b/legacy/user/revit/faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: FAQ
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/revit/features.mdx
+++ b/legacy/user/revit/features.mdx
@@ -1,5 +1,6 @@
 ---
 title: Features
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/revit/installing-updating-the-connector.mdx
+++ b/legacy/user/revit/installing-updating-the-connector.mdx
@@ -1,5 +1,6 @@
 ---
 title: Install & Update
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/revit/intro.mdx
+++ b/legacy/user/revit/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Revit
 sidebarTitle: Introduction
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/revit/receiving-models.mdx
+++ b/legacy/user/revit/receiving-models.mdx
@@ -1,5 +1,6 @@
 ---
 title: Receiving
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/revit/sending-models.mdx
+++ b/legacy/user/revit/sending-models.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sending
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/rhino.mdx
+++ b/legacy/user/rhino.mdx
@@ -1,5 +1,6 @@
 ---
 title: Rhino
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/sketchup/advanced-settings.mdx
+++ b/legacy/user/sketchup/advanced-settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Advanced Settings'
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/sketchup/basic-usage.mdx
+++ b/legacy/user/sketchup/basic-usage.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Basic Usage'
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/sketchup/installation.mdx
+++ b/legacy/user/sketchup/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Installation'
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/sketchup/introduction.mdx
+++ b/legacy/user/sketchup/introduction.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Introduction'
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/sketchup/manual-installation.mdx
+++ b/legacy/user/sketchup/manual-installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Manual Installation'
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/teklastructures.mdx
+++ b/legacy/user/teklastructures.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tekla Structures
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/unity.mdx
+++ b/legacy/user/unity.mdx
@@ -1,5 +1,6 @@
 ---
 title: Unity
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'

--- a/legacy/user/unreal.mdx
+++ b/legacy/user/unreal.mdx
@@ -1,5 +1,6 @@
 ---
 title: Unreal
+noindex: true
 ---
 
 import LegacyWarning from '/snippets/legacy-warning.mdx'


### PR DESCRIPTION
Implements a 'noindex' flag for multiple legacy documentation pages to prevent them from being indexed by search engines. This ensures that outdated content remains unlisted, improving the overall quality of the user experience.

Updates include various user guides and feature explanations across multiple platforms.
