### PR TITLE
Admin Support Mode docs: persona-based structure and customer focus

### DIFF
--- a/.universal-ai-config/instructions/docs-persona-audience.md
+++ b/.universal-ai-config/instructions/docs-persona-audience.md
@@ -1,0 +1,60 @@
+---
+description: User intent and persona by doc type — developers, users, IT support
+alwaysApply: true
+---
+
+# Docs Agent — Persona and Audience
+
+## User Intent and Persona by Doc Type
+
+Match the audience to the doc type. Write for the person viewing the docs.
+
+| Doc type | Audience | Intent |
+| --- | --- | --- |
+| **Developer docs** | Developers | Build, integrate, extend, debug |
+| **User guides** | Users | Use the product, publish, load, share, view |
+| **IT support docs** | IT teams supporting Speckle deployment | Deploy, configure, troubleshoot, support users |
+
+- Developer docs: env vars, APIs, SDKs, connectors, server setup.
+- User guides: workspaces, connectors (publish/load), 3D viewer, sharing.
+- IT support docs: deployment, admin support mode, workspace admin flows, enterprise features.
+
+## IT Support Audience Hierarchy
+
+Within IT support docs, the audience tiers are:
+
+1. **IT teams and workspace admins** — primary; enterprise customers who deploy or manage Speckle.
+2. **Server admins** — last tier; smallest audience. Includes Speckle ops running enterprise deployments and, to a lesser extent, customers who run servers with an enterprise license.
+
+When a feature involves both workspace admins and server admins, lead with workspace admins. Server admin content is for this narrow audience; repeat contextual Notes (e.g. Enterprise Server only) under their section so they see it when they jump there.
+
+## Audience Framing
+
+- All content is written for the reader — never assume Speckle internal staff.
+- **User guides**: "you" = the user. Plain language, task-first.
+- **IT support docs**: "you" = IT or workspace admin (the customer). Use "your server admin" when addressing workspace admins about someone else's role.
+- **Developer docs**: "you" = the developer. Technical, precise.
+
+## Partition by Persona (Multi-Role Features)
+
+- When a feature involves multiple roles (e.g. server admin, workspace admin), structure content by persona so readers can jump to their section.
+- Use "As a [role]" headings.
+- Lead with the gatekeeper role when the flow involves request-and-approve.
+- Put each role's actions under their section; do not mix both roles in one block.
+- Repeat Notes that apply to a persona under that persona's section (e.g. Enterprise Server only — repeat under "As a server admin").
+
+## Intent-First Intro
+
+- Lead with why and when (user intent, problem, scenario) before mechanics.
+- Prefer: "When a workspace issue requires support, your server admin may need to inspect or fix data."
+- Avoid: "This feature gives server administrators controlled, auditable access."
+
+## Step Outcomes and Verification
+
+- Each step ends with an observable outcome.
+- Add a verification line ("You should see...") after flows where failure is silent.
+
+## FAQ Hygiene
+
+- Remove FAQs that duplicate main content.
+- Keep FAQs that add value (edge cases, expiration, connectors).

--- a/workspaces/admin-support.mdx
+++ b/workspaces/admin-support.mdx
@@ -18,9 +18,9 @@ When admin support mode is enabled, server admins have different levels of acces
 | **Read** | No | View workspace projects, models, and versions to investigate issues |
 | **Write** | Yes (approved by workspace admin) | Edit projects, modify data, and make changes within the workspace |
 
-<Tip>
-For resources not tied to a workspace, server admins retain full read and write access without a support session.
-</Tip>
+<Note>
+For self-hosted deployments: when resources (projects and everything under them) are not tied to a workspace, server admins have full read and write access without a support session. If you self-host without an Enterprise license, there are no workspaces — server admins have full access in that case.
+</Note>
 
 ## How support sessions work
 

--- a/workspaces/admin-support.mdx
+++ b/workspaces/admin-support.mdx
@@ -3,7 +3,7 @@ title: "Admin Support Mode"
 description: "Enable and manage temporary admin access to workspaces for support purposes"
 ---
 
-Admin support mode gives server administrators controlled, auditable access to workspaces for troubleshooting and support. Server admins can read workspace data by default, but write access requires an explicit support session approved by a workspace admin.
+When a workspace issue requires support, your server admin may need to inspect or fix data. Admin support mode gives them controlled access while workspace admins stay in control. Server admins can read workspace data by default; write access requires an explicit support session approved by a workspace admin.
 
 <Note>
 Admin support mode is available only on Speckle Enterprise Server and is visible only to server administrators. For deployment and feature flag configuration, see the [Enterprise Licensed Server guide](/developers/server/deployment/enterprise-license#optional-admin-support-mode).
@@ -14,7 +14,7 @@ Admin support mode is available only on Speckle Enterprise Server and is visible
 When admin support mode is enabled, server admins have different levels of access depending on whether a support session is active:
 
 | Access level | Support session required? | What server admins can do |
-|---|---|---|
+| --- | --- | --- |
 | **Read** | No | View workspace projects, models, and versions to investigate issues |
 | **Write** | Yes (approved by workspace admin) | Edit projects, modify data, and make changes within the workspace |
 

--- a/workspaces/admin-support.mdx
+++ b/workspaces/admin-support.mdx
@@ -33,22 +33,56 @@ Support sessions follow a request-and-approve lifecycle:
 
 Multiple concurrent sessions are possible. A server admin can have active sessions for different workspaces, and a workspace can have active sessions from multiple server admins.
 
-## Request support access
+## As a workspace admin
 
-As a server admin:
+### Approve a support request
+
+<Steps>
+  <Step title="Open the Support settings page">
+    Open the email notification link, or go to **Workspace Settings > Support** for the relevant workspace. You see the sessions table with pending, active, and past sessions.
+  </Step>
+  <Step title="Review the pending request">
+    Find the pending request you want to review in the sessions table.
+  </Step>
+  <Step title="Approve the request">
+    Click the actions menu (**...**) on the session row and select **Approve**. The session status changes to **Active** and the server admin receives an email confirmation and gains write access.
+  </Step>
+</Steps>
+
+<Frame>
+  <img src="/images/workspaces/admin-support/approve-session.png" alt="Workspace Settings Support page showing the Approve and Revoke options in the actions menu" />
+</Frame>
+
+You should see the session status change to **Active** and the server admin receive an email confirmation.
+
+<Frame>
+  <img src="/images/workspaces/admin-support/active-session.png" alt="Active support session showing approval details" />
+</Frame>
+
+### Revoke a session
+
+Click the actions menu (**...**) on the session row in **Workspace Settings > Support** and select **Revoke**. Expired sessions appear with an **Expired** status in the sessions table.
+
+## As a server admin
+
+<Note>
+Admin support mode is available only on Speckle Enterprise Server and is visible only to server administrators. For deployment and feature flag configuration, see the [Enterprise Licensed Server guide](/developers/server/deployment/enterprise-license#optional-admin-support-mode).
+</Note>
+
+### Request support access
 
 <Steps>
   <Step title="Open workspace details">
-    Go to **Server Settings > Workspaces** and select the workspace you need to access.
+    Go to **Server Settings > Workspaces** and select the workspace you need to access. You see the workspace details page with the Support Access section.
   </Step>
   <Step title="Request access">
-    In the **Support Access** section, click **Request Support Access**.
+    In the **Support Access** section, click **Request Support Access**. The Request Support Access dialog opens.
   </Step>
   <Step title="Set an expiration (optional)">
     In the dialog, optionally set an expiration date and time. The minimum is 10 minutes from now. If left empty, the session will not expire and must be revoked manually.
   </Step>
   <Step title="Submit the request">
-    Click **Request Access**. All workspace admins receive an email notification with a link to review the request.
+    Click **Request Access**. The request status shows **Pending** in the Support Access section and all workspace admins receive an email notification with a link to review the request.
   </Step>
 </Steps>
 
@@ -60,41 +94,15 @@ As a server admin:
   <img src="/images/workspaces/admin-support/request-dialog.png" alt="Request Support Access dialog with optional expiration date" />
 </Frame>
 
-After submitting, the Support Access section shows the request status as **Pending** until a workspace admin approves or the server admin revokes it.
+You should see the request status as **Pending** in the Support Access section until a workspace admin approves or you revoke it.
 
 <Frame>
   <img src="/images/workspaces/admin-support/pending-session.png" alt="Pending support session showing status and expiration" />
 </Frame>
 
-## Approve a support request
+### Working in support mode
 
-As a workspace admin:
-
-<Steps>
-  <Step title="Open the Support settings page">
-    Open the email notification link, or go to **Workspace Settings > Support** for the relevant workspace.
-  </Step>
-  <Step title="Review the pending request">
-    The sessions table shows all pending, active, and past sessions. Find the pending request you want to review.
-  </Step>
-  <Step title="Approve the request">
-    Click the actions menu (**...**) on the session row and select **Approve**. The server admin receives an email confirmation and immediately gains write access.
-  </Step>
-</Steps>
-
-<Frame>
-  <img src="/images/workspaces/admin-support/approve-session.png" alt="Workspace Settings Support page showing the Approve and Revoke options in the actions menu" />
-</Frame>
-
-Once approved, the session status changes to **Active** and shows who approved it and when.
-
-<Frame>
-  <img src="/images/workspaces/admin-support/active-session.png" alt="Active support session showing approval details" />
-</Frame>
-
-## Working in support mode
-
-When a server admin has an active support session and navigates to the supported workspace, the interface changes to indicate support mode:
+When you have an active support session and navigate to the supported workspace, the interface changes to indicate support mode:
 
 - The navigation bar shows a red border and a red **Support mode** label
 - A session details icon appears in the navbar; clicking it shows the workspace name, who approved the session, the expiration, and an **End Support Session** button

--- a/workspaces/admin-support.mdx
+++ b/workspaces/admin-support.mdx
@@ -117,26 +117,13 @@ When you have an active support session and navigate to the supported workspace,
 
 Support sessions apply to all authentication tokens for the server admin, including connector sessions (Revit, Rhino, etc.).
 
-## Revoke or end a session
+### End or revoke a session
 
-Either party can end a support session at any time:
-
-- **Server admin:** Click **Revoke** in the Support Access section on the workspace's server settings page, or click **End Support Session** in the navbar dropdown while in support mode.
-- **Workspace admin:** Click the actions menu (**...**) on the session row in **Workspace Settings > Support** and select **Revoke**.
-
-Sessions also end automatically when the expiration time passes. Expired sessions appear with an **Expired** status in the sessions table.
+Click **Revoke** in the Support Access section on the workspace's server settings page, or click **End Support Session** in the navbar dropdown while in support mode. Sessions also end automatically when the expiration time passes.
 
 ## FAQ
 
 <AccordionGroup>
-  <Accordion title="What can a server admin do without a support session?">
-    With admin support mode enabled, server admins can view workspace data (projects, models, versions) without a support session. This read-only access lets admins investigate issues without needing workspace admin approval.
-  </Accordion>
-
-  <Accordion title="What additional access does an active support session grant?">
-    An active support session grants write access to the workspace. This includes editing projects, modifying data, and performing actions that change workspace contents. Read access is available without a session.
-  </Accordion>
-
   <Accordion title="What happens when a session expires?">
     The server admin loses write access immediately. The session appears as **Expired** in the sessions table. The admin retains read-only access (no session required). To regain write access, the admin must request a new session.
   </Accordion>


### PR DESCRIPTION
Restructured the Admin Support Mode page around user personas, clarified audience and intent, and aligned with the docs guidelines.
## Changes
### Audience and framing
- Reframed intro for enterprise customers (IT teams and workspace admins). Uses “your server admin” and “workspace admins stay in control” instead of addressing server admins directly.
- Content is written for customers viewing the docs, not for Speckle internal support.
### Structure
- Reorganized content by persona: As a workspace admin and as a server admin.
- Workspace admin section is first (approve/revoke flow).
- Server admin section follows (request, work in support mode, end session).
- Revoke instructions are split so each persona only sees their own actions.
### Intro
- Replaced system-focused intro with intent-first copy: “When a workspace issue requires support, your server admin may need to inspect or fix data…”
### Steps
- Added explicit outcomes to each step (e.g. “You see the sessions table…”, “The Request Support Access dialog opens”).
- Added verification lines (“You should see…”) after each flow.
### FAQs
- Removed two FAQs that repeated the Read vs write table:
   - “What can a server admin do without a support session?”
   - “What additional access does an active support session grant?”
- Kept FAQs on expiration, multiple admins, and connectors.
### Server admin section
- Repeated the Enterprise Server–only Note under As a server admin so server admins see it when they jump to that section.
### Formatting
- Adjusted table separator for markdownlint (MD060).