### PR TITLE
Adds guidance for Autodesk ACC permission handling

### DIFF
--- a/connectors/cloud-integrations/acc.mdx
+++ b/connectors/cloud-integrations/acc.mdx
@@ -97,6 +97,14 @@ If your organisation hasn't enabled the Speckle integration on the ACC Hub yet, 
          <img src="/images/connectors/cloud-integrations/acc/acc-premission warning.png" alt="Permission warning" />
        </Frame>
 
+    <Note>
+      **The warning comes from Autodesk, not Speckle.** Autodesk does not offer granular permission controls for Custom Integrations, so the dialog cannot show the actual scope.
+
+      **Speckle inherits each user's existing ACC permissions.** Users see only hubs, projects, and folders they already have access to. There is no elevation of access. Autodesk's API enforces these boundaries.
+
+      For extra control, create a dedicated ACC account with limited access to specific projects or folders and use it for Speckle syncs.
+    </Note>
+
     The Speckle integration is now enabled for your ACC account. Users can sign in from Speckle workspace settings and sync projects.
   </Step>
 </Steps>

--- a/connectors/cloud-integrations/acc.mdx
+++ b/connectors/cloud-integrations/acc.mdx
@@ -100,6 +100,8 @@ If your organisation hasn't enabled the Speckle integration on the ACC Hub yet, 
     <Note>
       **The warning comes from Autodesk, not Speckle.** Autodesk does not offer granular permission controls for Custom Integrations, so the dialog cannot show the actual scope.
 
+      **Speckle requests only read-only scopes** (`account:read`, `user-profile:read`, `data:read`, `data:search`, `bucket:read`, `viewables:read`, `openid`) to reach files and metadata for conversion. See [Autodesk's scope definitions](https://aps.autodesk.com/en/docs/oauth/v2/developers_guide/scopes/) for details.
+
       **Speckle inherits each user's existing ACC permissions.** Users see only hubs, projects, and folders they already have access to. There is no elevation of access. Autodesk's API enforces these boundaries.
 
       For extra control, create a dedicated ACC account with limited access to specific projects or folders and use it for Speckle syncs.


### PR DESCRIPTION
### Summary
Enhances the cloud integrations documentation by adding a note to clarify Autodesk ACC permission handling when using Speckle.

### Why this change was needed
Users were unclear about the source and handling of permission warnings linked to Autodesk ACC integrations, leading to potential security and access misconceptions.

### What changed
- Added a note explaining that permission warnings originate from Autodesk rather than Speckle.
- Clarified that Speckle adheres to existing user permissions set within ACC.
- Suggested creating a dedicated ACC account for users needing specific project access.

### Notes for reviewers
- Verify the clarity of the new guidance in regard to user permissions and its implications.
- Consider if additional clarification might be needed in other sections of the documentation.