### PR TITLE
Adds email deliverability section and updates phrasing

### DIFF
--- a/workspaces/it-setup.mdx
+++ b/workspaces/it-setup.mdx
@@ -33,6 +33,13 @@ This page is scoped to IT administrative tasks only. For end-user guides, see [C
     Network and firewall configuration requirements
   </Card>
   <Card
+    title="Email Deliverability"
+    icon="envelope"
+    href="#email-deliverability-ip-allowlisting"
+  >
+    IP allowlisting for system emails
+  </Card>
+  <Card
     title="Additional Resources"
     icon="book"
     href="#additional-resources"
@@ -169,6 +176,48 @@ For the most current IP ranges or assistance with firewall configuration, contac
 
 <Note>
 For organizations with strict egress controls, consider deploying a self-hosted Speckle server to keep all traffic within your network.
+</Note>
+
+## Email Deliverability: IP Allowlisting
+
+To ensure reliable delivery of system emails (notifications, alerts, reports, etc.), customers with strict email security policies may need to allowlist the IP ranges used by our email delivery provider.
+
+If your organization uses email gateways, spam filters, or firewall rules that restrict incoming email traffic, add the following IP ranges to your allowlist.
+
+### Sending IP Ranges
+
+- `205.201.128.0/20`
+- `198.2.128.0/18`
+- `148.105.0.0/16`
+
+### What This Means
+
+These CIDR ranges are used by our email service provider to send outbound messages. Allowlisting them helps ensure that messages from our platform are not blocked or quarantined by your email security infrastructure.
+
+### Who Should Configure This
+
+This is typically configured by your:
+
+- Email administrators
+- IT or security team
+- Network or firewall administrators
+
+### Where to Add the Allowlist
+
+Depending on your environment, the IP ranges may need to be added to:
+
+- Email security gateways (e.g., Proofpoint, Mimecast, Barracuda)
+- Spam filtering systems
+- Microsoft 365 / Exchange mail flow rules
+- Google Workspace allowlists
+- Network firewalls or secure email gateways
+
+<Tip>
+Add these ranges to your trusted sender or inbound allowlist policies to prevent email filtering or blocking.
+</Tip>
+
+<Note>
+These IP ranges are maintained by our email provider and may change periodically. If your organization requires domain-based allowlisting instead, contact [support@speckle.systems](mailto:support@speckle.systems).
 </Note>
 
 ## Additional Resources

--- a/workspaces/it-setup.mdx
+++ b/workspaces/it-setup.mdx
@@ -168,7 +168,7 @@ For self-hosted deployments, see the [Server Deployment Guide](/developers/serve
 
 `app.speckle.systems` is served through Cloudflare, which uses a global CDN with dynamic IP addresses that change frequently. For this reason, domain-based firewall rules are strongly recommended over IP-based rules.
 
-If your organization requires IP-based firewall rules, you can reference [Cloudflare's published IP ranges](https://www.cloudflare.com/ips/). However, these ranges are large and change regularly, making domain-based rules more reliable and easier to maintain.
+If your organization requires IP-based firewall rules, you can refer to [Cloudflare's published IP ranges](https://www.cloudflare.com/ips/). However, these ranges are large and change regularly, making domain-based rules more reliable and easier to maintain.
 
 <Info>
 For the most current IP ranges or assistance with firewall configuration, contact [support@speckle.systems](mailto:support@speckle.systems).
@@ -247,7 +247,7 @@ These IP ranges are maintained by our email provider and may change periodically
   </Accordion>
   
   <Accordion title="Can we use IP addresses instead of domain names?">
-    We strongly recommend using domain names. `app.speckle.systems` is served through Cloudflare, which uses a global CDN with dynamic IP addresses that change frequently. Domain-based rules are more reliable and easier to maintain. If IP-based rules are required, reference [Cloudflare's published IP ranges](https://www.cloudflare.com/ips/) or contact support for assistance.
+    We strongly recommend using domain names. `app.speckle.systems` is served through Cloudflare, which uses a global CDN with dynamic IP addresses that change frequently. Domain-based rules are more reliable and easier to maintain. If IP-based rules are required, refer to [Cloudflare's published IP ranges](https://www.cloudflare.com/ips/) or contact support for assistance.
   </Accordion>
   
   <Accordion title="Do connectors work behind a corporate proxy?">

--- a/workspaces/it-setup.mdx
+++ b/workspaces/it-setup.mdx
@@ -58,7 +58,7 @@ Speckle connectors enable users to publish and load data from design application
 - **Desktop UI (DUI)**: Updated centrally and automatically propagates to all connectors without requiring connector updates. This shared interface handles authentication and common workflows.
 - **Connector addons**: Updated separately for each connector. Each application-specific connector (Revit, Rhino, etc.) must be updated individually.
 
-When deploying connectors manually, you only need to update connector addons. DUI updates automatically. To prevent update checks, contact [support@speckle.systems](mailto:support@speckle.systems) for a file to replace the connector configuration database. A download link will be available in the manual installation guides in future.
+When deploying connectors manually, you only need to update connector addons. DUI updates automatically. To prevent update checks, contact [support@speckle.systems](mailto:support@speckle.systems) for a file to replace the connector configuration database. A download link will be added to the manual installation guides in a future update.
 </Warning>
 
 <Note>


### PR DESCRIPTION
## Summary

Introduces an email deliverability section with IP allowlisting details. Enhances consistency and clarity in phrasing related to updates and Cloudflare IP references.

## Why this change was needed

The changes aim to address the need for clear guidelines on ensuring system email deliverability, particularly for organisations with strict email security. Additionally, language improvements enhance documentation clarity and maintainability.

## What changed

- Added a new section on email deliverability, including IP ranges for allowlisting and configuration guidance.
- Updated phrasing to consistently use "refer" regarding Cloudflare's IP ranges.
- Improved wording related to future update mentions for improved clarity.