### PR TITLE
Adds noindex tag and updates links to nofollow

### DIFF
--- a/connectors/manual-installation/archicad.mdx
+++ b/connectors/manual-installation/archicad.mdx
@@ -1,6 +1,7 @@
 ---
 title: Archicad
 description: "Manual installation instructions for Speckle Archicad connector via ZIP"
+noindex: true
 ---
 
 <Warning>

--- a/connectors/manual-installation/blender.mdx
+++ b/connectors/manual-installation/blender.mdx
@@ -1,6 +1,7 @@
 ---
 title: Blender
 description: "Manual installation instructions for Speckle Blender connector via ZIP"
+noindex: true
 ---
 
 import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';

--- a/connectors/manual-installation/desktop-services.mdx
+++ b/connectors/manual-installation/desktop-services.mdx
@@ -1,6 +1,7 @@
 ---
 title: Desktop Services
 description: "Manual installation instructions for Speckle Desktop Services via ZIP"
+noindex: true
 ---
 
 import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';

--- a/connectors/manual-installation/etabs.mdx
+++ b/connectors/manual-installation/etabs.mdx
@@ -1,6 +1,7 @@
 ---
 title: ETABS
 description: "Manual installation instructions for Speckle ETABS connector via ZIP"
+noindex: true
 ---
 
 <Warning>

--- a/connectors/manual-installation/introduction.mdx
+++ b/connectors/manual-installation/introduction.mdx
@@ -24,7 +24,7 @@ import { EtabsIcon } from '/snippets/components/EtabsIcon.jsx';
 
 ## Download Connector ZIP Files
 
-Download connector ZIP files from [releases.speckle.systems](https://releases.speckle.systems/). Select the connector and version you need for your deployment.
+Download connector ZIP files from <a href="https://releases.speckle.systems/" rel="nofollow">releases.speckle.systems</a>. Select the connector and version you need for your deployment.
 
 ## Supported Connectors
 

--- a/connectors/manual-installation/introduction.mdx
+++ b/connectors/manual-installation/introduction.mdx
@@ -2,6 +2,7 @@
 title: Manual installation
 sidebarTitle: Overview
 description: "Deploy Speckle connectors manually via ZIP files for IT administrators"
+noindex: true
 ---
 
 import { RevitIcon } from '/snippets/components/RevitIcon.jsx';

--- a/connectors/manual-installation/navisworks.mdx
+++ b/connectors/manual-installation/navisworks.mdx
@@ -1,6 +1,7 @@
 ---
 title: Navisworks
 description: "Manual installation instructions for Speckle Navisworks connector via ZIP"
+noindex: true
 ---
 
 import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';

--- a/connectors/manual-installation/powerbi.mdx
+++ b/connectors/manual-installation/powerbi.mdx
@@ -1,6 +1,7 @@
 ---
 title: Power BI
 description: "Manual installation instructions for Speckle Power BI connector via ZIP"
+noindex: true
 ---
 
 import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';

--- a/connectors/manual-installation/revit.mdx
+++ b/connectors/manual-installation/revit.mdx
@@ -1,6 +1,7 @@
 ---
 title: Revit
 description: "Manual installation instructions for Speckle Revit connector via ZIP"
+noindex: true
 ---
 
 import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';

--- a/connectors/manual-installation/rhino-grasshopper.mdx
+++ b/connectors/manual-installation/rhino-grasshopper.mdx
@@ -1,6 +1,7 @@
 ---
 title: Rhino & Grasshopper
 description: "Manual installation instructions for Speckle Rhino and Grasshopper connectors via ZIP"
+noindex: true
 ---
 
 import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';

--- a/connectors/manual-installation/sketchup.mdx
+++ b/connectors/manual-installation/sketchup.mdx
@@ -1,6 +1,7 @@
 ---
 title: SketchUp
 description: "Manual installation instructions for Speckle SketchUp connector via ZIP"
+noindex: true
 ---
 
 import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';

--- a/connectors/manual-installation/tekla.mdx
+++ b/connectors/manual-installation/tekla.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tekla Structures
 description: "Manual installation instructions for Speckle Tekla Structures connector via ZIP"
+noindex: true
 ---
 
 import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';

--- a/workspaces/archived-projects.mdx
+++ b/workspaces/archived-projects.mdx
@@ -1,6 +1,7 @@
 ---
 title: Archive and unarchive projects
 description: "Hide inactive projects without deleting their data"
+noindex: true
 sidebarTitle: Project Archival
 tag: Enterprise
 ---

--- a/workspaces/it-setup.mdx
+++ b/workspaces/it-setup.mdx
@@ -79,7 +79,7 @@ Users can download and install connectors directly from [app.speckle.systems/con
 
 For environments that restrict executable installers or require centralized deployment, use manual ZIP-based installation:
 
-- **Download ZIP files:** [releases.speckle.systems](https://releases.speckle.systems/)
+- **Download ZIP files:** <a href="https://releases.speckle.systems/" rel="nofollow">releases.speckle.systems</a>
 - **Installation instructions:** [Manual Installation Guide](/connectors/manual-installation/introduction)
 
 The manual installation guide includes step-by-step instructions for all supported connectors, including the required Desktop Services background service.


### PR DESCRIPTION
Prevents search engines from indexing manual installation pages by adding a noindex tag. Updates external links to releases site with a nofollow attribute to prevent passing SEO value. These changes enhance control over the visibility of technical resources.

Relates to task associated with jonathon/no-crawl-it-pages