### PR TITLE
fix: teklastructures slug redirect

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -43,6 +43,10 @@
     {
       "source": "/analytics/model-checker/rules-and-rulesets",
       "destination": "/analytics/data-validation/rules-and-rulesets"
+    },
+    {
+      "source": "/connectors/teklastructures",
+      "destination": "/connectors/tekla"
     }
   ],
   "navigation": {


### PR DESCRIPTION
Adds a redirect in docs.json so that any existing links or bookmarks pointing to the old Tekla Structures connector URL are automatically forwarded to the renamed page. Prevents 404s for users.