### PR TITLE
Fixes misplaced closing tags in documentation

### DIFF
--- a/connectors/direct-uploads/introduction.mdx
+++ b/connectors/direct-uploads/introduction.mdx
@@ -185,7 +185,8 @@ SketchUp models are converted with geometry and basic organization preserved.
 
 - Attributes aren't imported
 - Dynamic components may not transfer correctly
-  </Info>
+
+</Info>
 
 ### DWG and DXF
 
@@ -201,7 +202,8 @@ Upload AutoCAD drawing files directly. Results may vary depending on file comple
 
 - Large files may take longer to process
 - Dynamic text isn't supported
-  </Info>
+
+</Info>
 
 ### Wavefront (OBJ)
 
@@ -211,7 +213,8 @@ OBJ files are converted with geometry preserved.
   **Known limitations**
 
 - Materials aren't supported
-  </Info>
+
+</Info>
 
 ## FAQ
 

--- a/developers/api/webhooks/security.mdx
+++ b/developers/api/webhooks/security.mdx
@@ -75,7 +75,8 @@ if (!isValid) {
 - Use conditional logic to exit early when no action is required
 - Implement idempotency checks to avoid reprocessing the same event
 - Monitor your webhook endpoint for unusual activity patterns
-  </Warning>
+
+</Warning>
 
 ## Best Practices
 


### PR DESCRIPTION
Corrects the positioning of closing tags in direct-upload and webhooks security documentation for better readability and accuracy.

Related to branch "jonathon/tagfixes".