### PR TITLE
Renames ACC to Autodesk Forma Data Management

### DIFF
--- a/connectors/cloud-integrations/acc.mdx
+++ b/connectors/cloud-integrations/acc.mdx
@@ -1,51 +1,41 @@
 ---
-title: "Autodesk Construction Cloud"
-sidebarTitle: "Autodesk Construction Cloud"
-description: "Connect and sync your Autodesk Construction Cloud models with Speckle for analytics, dashboards, and automation workflows."
+title: "Autodesk Forma Data Management"
+sidebarTitle: "Forma Data Management (ACC)"
+description: "Connect and sync models from Autodesk Forma Data Management — the Autodesk cloud platform still widely known as ACC — with Speckle for analytics, dashboards, and automation workflows."
 ---
 
 import CoordinationWorkflowRevit from "/snippets/connectors/coordination-workflow-revit.mdx";
 
+<Note>
+  **Autodesk Forma Data Management** is the current name for **Autodesk Construction Cloud (ACC)**; labels and URLs may still say ACC. Before anyone can sign in, the integration must be enabled on your **ACC Hub**. If workspace settings do not show a Forma / ACC login option, your IT administrator needs to add the integration in Autodesk admin first — see [Enabling the integration (IT Admin)](#enabling-the-integration-on-acc-it-admin).
+</Note>
+
 <Info>
-  The Autodesk Construction Cloud integration is available on **Team** and
-  **Enterprise** plans. To enable it for your organisation,{" "}
-  <a href="mailto:office@speckle.systems?subject=Autodesk%20Construction%20Cloud%20Integration%20enquiry">
-    get a quote
-  </a>{" "}
-  or see [New plans FAQ](/workspaces/new-plans-faq) for plan details.
+  The Autodesk Forma Data Management integration is available on **Team** and
+  **Enterprise** plans.
 </Info>
 
-<Note>
-  The Speckle integration must be enabled on your ACC Hub before you can sign
-  in. If you don't see the option to log in to Autodesk Construction Cloud in
-  Speckle workspace settings, your IT administrator needs to add the integration
-  in ACC first. See [Enabling the integration on ACC (IT
-  Admin)](#enabling-the-integration-on-acc-it-admin) for the steps they follow.
-</Note>
-
-<Note>
-  Want to shape this workflow? Join the user testing study for NWC and NWD
-  uploads with ACC sync on the [User testing opportunities
-  page](/get-involved/user-testing#nwc-nwd-acc-sync).
-</Note>
+<Tip>
+  Help shape Navisworks workflows: join the NWC/NWD user testing study ([details](/get-involved/user-testing#nwc-nwd-acc-sync)).
+</Tip>
 
 ## Setup
 
-These steps assume the Speckle integration has already been enabled on your organisation's ACC Hub. If it hasn't, your IT administrator must complete the steps in [Enabling the integration on ACC (IT Admin)](#enabling-the-integration-on-acc-it-admin) first.
+These steps assume the Speckle integration has already been enabled on your organisation's ACC Hub for Forma Data Management. If it hasn't, your IT administrator must complete the steps in [Enabling the integration (IT Admin)](#enabling-the-integration-on-acc-it-admin) first.
 
 <Steps>
-  <Step title="Sign in to Autodesk Construction Cloud">
+  <Step title="Sign in to Autodesk Forma Data Management">
     1. Select **workspace settings** from the workspace dropdown (top left).
 
        <Frame>
          <img src="/images/connectors/cloud-integrations/acc/acc-workspace settings.png" alt="Workspace settings" />
        </Frame>
-    2. Select **Log in** next to Autodesk Construction Cloud.
+    2. Select **Log in** next to Forma Data Management or **Autodesk Construction Cloud (ACC)** — the label may not have updated yet.
 
        <Frame>
          <img src="/images/connectors/cloud-integrations/acc/acc-login.png" alt="Login" />
        </Frame>
-    3. Sign in to your ACC account and select **Allow** from the authorization dialog.
+    3. Sign in to your Autodesk account and select **Allow** from the authorization dialog.
 
        <Frame>
          <img src="/images/connectors/cloud-integrations/acc/acc-authorize app.png" alt="Authorize app" />
@@ -115,8 +105,8 @@ If your organisation hasn't enabled the Speckle integration on the ACC Hub yet, 
 </Info>
 
 <Steps>
-  <Step title="Add a custom integration to ACC">
-    1. Go to the [ACC Account Admin](https://acc.autodesk.com/) page (or [acc.autodesk.eu](https://acc.autodesk.eu/) for the European region).
+  <Step title="Add a custom integration in Autodesk admin">
+    1. Go to [Autodesk Account Admin](https://acc.autodesk.com/) — URL still uses **acc.** — or [acc.autodesk.eu](https://acc.autodesk.eu/) for the European region.
     2. In the Account Admin panel, select **Custom Integrations**.
     3. Select **Add custom integrations**.
     4. Enter the integration details (copy the Client ID exactly, with no extra spaces):

--- a/connectors/cloud-integrations/acc.mdx
+++ b/connectors/cloud-integrations/acc.mdx
@@ -76,7 +76,7 @@ The following file formats are currently supported for syncing from Autodesk For
 | Navisworks | `.nwc` `.nwd` | ⚠️ Beta      |
 
 <Info>
-  Navisworks files (`.nwc` and `.nwd`) are supported for manual upload and ACC
+  Navisworks files (`.nwc` and `.nwd`) are supported for manual upload and Forma Data Management
   sync as a beta feature. Many Autodesk (and other) products can export
   Navisworks Cache files without requiring a Navisworks license, so you can
   upload those exports to Speckle.
@@ -172,14 +172,14 @@ This is useful when you want to:
 
 <AccordionGroup>
   <Accordion title="Is the connection read-only?">
-    Yes. Speckle establishes a read-only connection with Autodesk Construction Cloud, which means we can sync and analyze your data but can't modify the original files. This ensures data integrity and security.
+    Yes. Speckle establishes a read-only connection with Autodesk Forma Data Management (ACC), which means we can sync and analyze your data but can't modify the original files. This ensures data integrity and security.
   </Accordion>
   <Accordion title="How often do files sync?">
-    Once you've created a sync model, it automatically syncs whenever a new version of the file is published to Autodesk Construction Cloud. You don't need to manually trigger ongoing synchronization.
+    Once you've created a sync model, it automatically syncs whenever a new version of the file is published to Autodesk Forma Data Management. You don't need to manually trigger ongoing synchronization.
   </Accordion>
   <Accordion title="Why are my models in the wrong location?">
     Use the reference point input in the sync configuration to control placement for coordination workflows. If the
-    selected reference point in ACC does not match your downstream model setup, placement can still appear offset.
+    selected reference point in Forma Data Management sync does not match your downstream model setup, placement can still appear offset.
     For project-by-project control and advanced receive options, you can also use the [Revit connector](/connectors/revit/revit).
   </Accordion>
   <Accordion title="What if my sync fails?">
@@ -195,26 +195,26 @@ This is useful when you want to:
   <Accordion title="How do I get access?">
     Contact us at [hello@speckle.systems](mailto:hello@speckle.systems) to request access.
   </Accordion>
-  <Accordion title="What's the difference between the ACC integration and other integrations?">
-    The ACC integration provides direct integration with Autodesk Construction Cloud and enables automatic synchronization of construction data. Unlike other integrations that require manual file uploads or connectors, ACC syncs happen automatically when files are updated in the cloud.
+  <Accordion title="What's the difference between the Forma Data Management integration and other integrations?">
+    The Forma Data Management (ACC) integration connects Speckle to Autodesk cloud construction data and enables automatic synchronization. Unlike other integrations that require manual file uploads or connectors, cloud syncs happen automatically when files are updated.
   </Accordion>
-  <Accordion title="Can I use Autodesk Construction Cloud models with Speckle Intelligence?">
-    Yes. Once synced, your Autodesk Construction Cloud models can be used with Speckle Intelligence for analytics, dashboard creation, and generating insights from your construction data.
+  <Accordion title="Can I use Autodesk Forma Data Management models with Speckle Intelligence?">
+    Yes. Once synced, your models can be used with Speckle Intelligence for analytics, dashboard creation, and generating insights from your construction data.
   </Accordion>
 </AccordionGroup>
 
 ## Roadmap
 
-| Feature                                  | Status         |
-| ---------------------------------------- | -------------- |
-| ACC account connection and authorization | ✅ Complete    |
-| Revit (`.rvt`) file synchronization      | ✅ Complete    |
-| IFC (`.ifc`) file synchronization        | ✅ Complete    |
-| Automatic sync on file updates           | ✅ Complete    |
-| Basic sync status monitoring             | ✅ Complete    |
-| Enhanced UI/UX for sync management       | ✅ Complete    |
-| Advanced sync configuration options      | 🔄 In Progress |
-| Improved error handling and reporting    | 🔄 In Progress |
+| Feature                                                   | Status         |
+| --------------------------------------------------------- | -------------- |
+| Forma Data Management account connection and authorization | ✅ Complete    |
+| Revit (`.rvt`) file synchronization                       | ✅ Complete    |
+| IFC (`.ifc`) file synchronization                         | ✅ Complete    |
+| Automatic sync on file updates                            | ✅ Complete    |
+| Basic sync status monitoring                              | ✅ Complete    |
+| Enhanced UI/UX for sync management                        | ✅ Complete    |
+| Advanced sync configuration options                       | 🔄 In Progress |
+| Improved error handling and reporting                     | 🔄 In Progress |
 
 ## Getting Help
 

--- a/connectors/cloud-integrations/acc.mdx
+++ b/connectors/cloud-integrations/acc.mdx
@@ -45,12 +45,12 @@ These steps assume the Speckle integration has already been enabled on your orga
 
   </Step>
   <Step title="Sync your first model">
-    1. From your project in Speckle, select **Add model \> Sync from ACC**.
+    1. From your project in Speckle, select **Add model \> Sync from ACC** (command may still use the **ACC** name).
 
        <Frame>
          <img src="/images/connectors/cloud-integrations/acc/acc-add model.png" alt="Add model" />
        </Frame>
-    2. Select the file you want to sync. Your hubs, projects, folders and files from ACC will be listed here.
+    2. Select the file you want to sync. Your hubs, projects, folders and files from Forma Data Management will be listed here.
        <Frame>
          <img src="/images/connectors/cloud-integrations/acc/acc-select file.png" alt="Select file" />
        </Frame>
@@ -60,14 +60,14 @@ These steps assume the Speckle integration has already been enabled on your orga
        </Frame>
     4. Select **Create**.
 
-    This connects your ACC file to your Speckle model. Changes in ACC sync automatically to Speckle.
+    This connects your Forma Data Management file to your Speckle model. Changes in Autodesk cloud storage sync automatically to Speckle.
 
   </Step>
 </Steps>
 
 ## Supported File Formats
 
-The following file formats are currently supported for syncing from Autodesk Construction Cloud:
+The following file formats are currently supported for syncing from Autodesk Forma Data Management:
 
 | Format     | Extension     | Status       |
 | ---------- | ------------- | ------------ |
@@ -95,9 +95,11 @@ The following file formats are currently supported for syncing from Autodesk Con
 
 <CoordinationWorkflowRevit />
 
-## Enabling the integration on ACC (IT Admin)
+<a id="enabling-the-integration-on-acc-it-admin" />
 
-If your organisation hasn't enabled the Speckle integration on the ACC Hub yet, an IT administrator (or anyone with **Account Admin** access in ACC) must add it first. After that, users can sign in from Speckle workspace settings and sync projects as described in [Setup](#setup) above.
+## Enabling the integration (IT Admin)
+
+If your organisation hasn't enabled the Speckle integration on the ACC Hub yet, an IT administrator (or anyone with **Account Admin** access — Forma Data Management still uses **acc.autodesk.com** and ACC-branded admin) must add it first. After that, users can sign in from Speckle workspace settings and sync projects as described in [Setup](#setup) above.
 
 <Info>
   If **Custom Integrations** is not visible in the Account Admin panel, the
@@ -128,19 +130,19 @@ If your organisation hasn't enabled the Speckle integration on the ACC Hub yet, 
 
       **Speckle requests only read-only scopes** (`account:read`, `user-profile:read`, `data:read`, `data:search`, `bucket:read`, `viewables:read`, `openid`) to reach files and metadata for conversion. See [Autodesk's scope definitions](https://aps.autodesk.com/en/docs/oauth/v2/developers_guide/scopes/) for details.
 
-      **Speckle inherits each user's existing ACC permissions.** Users see only hubs, projects, and folders they already have access to. There is no elevation of access. Autodesk's API enforces these boundaries.
+      **Speckle inherits each user's existing permissions in Autodesk Forma Data Management (ACC).** Users see only hubs, projects, and folders they already have access to. There is no elevation of access. Autodesk's API enforces these boundaries.
 
-      For extra control, create a dedicated ACC account with limited access to specific projects or folders and use it for Speckle syncs.
+      For extra control, create a dedicated Autodesk account with limited access to specific projects or folders and use it for Speckle syncs.
     </Note>
 
-    The Speckle integration is now enabled for your ACC account. Users can sign in from Speckle workspace settings and sync projects.
+    The Speckle integration is now enabled for your Autodesk account. Users can sign in from Speckle workspace settings and sync projects.
 
   </Step>
 </Steps>
 
 ## View Selection
 
-When syncing a Revit file from ACC, you can optionally specify a view name to control which elements are included in the sync.
+When syncing a Revit file from Forma Data Management, you can optionally specify a view name to control which elements are included in the sync.
 
 ### No view specified (default)
 

--- a/connectors/overview.mdx
+++ b/connectors/overview.mdx
@@ -7,7 +7,7 @@ description: "Publish and load 3D models using connectors, cloud integrations, o
 ## Ways to Get Data Into Speckle
 
 - **Connectors** - Plugins inside your design tools for meaningful exchanges
-- **Cloud integrations** - Automatic sync from cloud platforms like Autodesk Construction Cloud
+- **Cloud integrations** - Automatic sync from cloud platforms like Autodesk Forma Data Management (still often called ACC)
 - **File uploads** - Direct uploads when a connector is not available
 
 Only connectors support loading data back into your design tools.
@@ -39,9 +39,9 @@ Cloud integrations connect Speckle directly to cloud-based platforms. Data syncs
 
 ### Available Integrations
 
-- **[Autodesk Construction Cloud (ACC)](/connectors/cloud-integrations/acc)** - Sync Revit files from ACC projects
+- **[Autodesk Forma Data Management (ACC)](/connectors/cloud-integrations/acc)** — Sync Revit files from Autodesk cloud projects (still often called ACC)
 
-<Note>The ACC integration is available on **Team** and **Enterprise** plans. See the [ACC integration guide](/connectors/cloud-integrations/acc) for setup details.</Note>
+<Note>The Forma Data Management integration is available on **Team** and **Enterprise** plans. See the [Forma Data Management integration guide](/connectors/cloud-integrations/acc) for setup details.</Note>
 
 ## File Uploads
 

--- a/snippets/connectors/coordination-workflow-revit.mdx
+++ b/snippets/connectors/coordination-workflow-revit.mdx
@@ -1,3 +1,3 @@
 <Warning>
-ACC sync and direct uploads convert models using Internal Origin and do not apply Revit Shared Coordinates. Models brought in via sync or upload are not placed in a coordinated space. For coordination workflows that rely on Shared Coordinates, use the [Revit connector](/connectors/revit/revit) to publish and load models so coordinate modifications are preserved.
+Forma Data Management (ACC) sync and direct uploads convert models using Internal Origin and do not apply Revit Shared Coordinates. Models brought in via sync or upload are not placed in a coordinated space. For coordination workflows that rely on Shared Coordinates, use the [Revit connector](/connectors/revit/revit) to publish and load models so coordinate modifications are preserved.
 </Warning>

--- a/workspaces/introduction.mdx
+++ b/workspaces/introduction.mdx
@@ -22,7 +22,7 @@ Use this page as a quick map of where to go next.
 <Frame caption="Integrations, cloud integrations, and dashboards on workspace home">
   <img
     src="/images/workspaces/workspace-bottom.png"
-    alt="Speckle workspace home (lower): connector install cards, cloud integrations such as Autodesk Construction Cloud, and latest shared dashboards table"
+    alt="Speckle workspace home (lower): connector install cards, cloud integrations such as Autodesk Forma Data Management (ACC), and latest shared dashboards table"
   />
 </Frame>
 

--- a/workspaces/it-setup.mdx
+++ b/workspaces/it-setup.mdx
@@ -80,11 +80,11 @@ For environments that restrict executable installers or require centralized depl
 
 The manual installation guide includes step-by-step instructions for all supported connectors, including the required Desktop Services background service.
 
-### Autodesk Construction Cloud (ACC)
+### Autodesk Forma Data Management (ACC)
 
-ACC setup is user-led after the integration is enabled. **IT Administrators** are responsible for enabling the Speckle integration on the ACC Hub. Once enabled, users sign in from Speckle workspace settings and follow the [ACC integration guide](/connectors/cloud-integrations/acc) for project syncing.
+Setup is user-led after the integration is enabled. **IT Administrators** enable the Speckle integration on the **ACC Hub** (Autodesk Forma Data Management admin). Once enabled, users sign in from Speckle workspace settings and follow the [Forma Data Management integration guide](/connectors/cloud-integrations/acc) for project syncing.
 
-[Enable the integration on ACC (step-by-step)](/connectors/cloud-integrations/acc#enabling-the-integration-on-acc-it-admin)
+[Enable the integration (IT Admin, step-by-step)](/connectors/cloud-integrations/acc#enabling-the-integration-on-acc-it-admin)
 
 ## Single sign-on (SSO)
 

--- a/workspaces/new-plans-faq.mdx
+++ b/workspaces/new-plans-faq.mdx
@@ -375,13 +375,15 @@ We're genuinely grateful for the trust you've placed in Speckle and remain commi
   </Accordion>
 </AccordionGroup>
 
-## ACC integration
+<a id="acc-integration" />
+
+## Forma Data Management (ACC) integration
 
 <AccordionGroup>
-  <Accordion title="What happens to existing ACC connections if I downgrade from Team or Enterprise?">
+  <Accordion title="What happens to existing Forma Data Management / ACC connections if I downgrade from Team or Enterprise?">
     Connections are paused but retained. The connection configuration remains,
     but syncing stops. Upgrading back to Team or Enterprise restores syncing.
-    Confirm that ACC syncing is no longer required before downgrading.
+    Confirm that cloud syncing from Autodesk is no longer required before downgrading.
   </Accordion>
 </AccordionGroup>
 

--- a/workspaces/new-plans-faq.mdx
+++ b/workspaces/new-plans-faq.mdx
@@ -159,11 +159,11 @@ We're genuinely grateful for the trust you've placed in Speckle and remain commi
 
   </Accordion>
 
-<Accordion title="How does ACC integration work across plans?">
-  ACC syncing is a continuous, governed integration requiring enterprise-level
+<Accordion title="How does Forma Data Management (ACC) integration work across plans?">
+  Forma Data Management syncing — still commonly called **ACC** sync — is a continuous, governed integration requiring enterprise-level
   reliability and compliance. It is available on **Team** and **Enterprise**
-  plans. Each ACC-connected project maps to a Speckle project and counts toward
-  project limits. If you downgrade from Team or Enterprise, ACC connections are
+  plans. Each cloud-connected project maps to a Speckle project and counts toward
+  project limits. If you downgrade from Team or Enterprise, those connections are
   paused but retained; upgrading to Team or Enterprise restores syncing.
 </Accordion>
 
@@ -299,9 +299,9 @@ We're genuinely grateful for the trust you've placed in Speckle and remain commi
   upgraded again.
 </Accordion>
 
-<Accordion title="Does each ACC-connected project count as a project in Speckle?">
-  Yes, each ACC integration maps to a Speckle project and counts toward project
-  limits. Plan ACC integrations with project limits in mind. ACC syncing is
+<Accordion title="Does each Forma Data Management / ACC-connected project count as a project in Speckle?">
+  Yes, each Forma Data Management (ACC) integration maps to a Speckle project and counts toward project
+  limits. Plan cloud integrations with project limits in mind. Syncing from Autodesk cloud projects is
   available on Team and Enterprise plans.
 </Accordion>
 

--- a/workspaces/plans-and-governance.mdx
+++ b/workspaces/plans-and-governance.mdx
@@ -180,28 +180,28 @@ Use this checklist when setting up a new governed workspace:
   </Accordion>
 </AccordionGroup>
 
-### ACC integration governance
+### Forma Data Management (ACC) integration governance
 
 <AccordionGroup>
-  <Accordion title="Does ACC data get copied into Speckle SaaS?">
-    In ACC integration workflows, Speckle reads source files from ACC and creates
+  <Accordion title="Does Forma Data Management / ACC data get copied into Speckle SaaS?">
+    In Forma Data Management (ACC) integration workflows, Speckle reads source files from Autodesk cloud storage and creates
     synced models in Speckle for viewing, coordination, and downstream workflows.
 
-    The ACC integration is documented as read-only from Speckle to ACC, so
-    Speckle does not write changes back to your ACC source files. See [Autodesk
-    Construction Cloud](/connectors/cloud-integrations/acc).
+    The integration is documented as read-only from Speckle to Autodesk cloud sources, so
+    Speckle does not write changes back to your source files. See [Autodesk
+    Forma Data Management (ACC)](/connectors/cloud-integrations/acc).
   </Accordion>
-  <Accordion title="Does Speckle change data in ACC?">
-    No. ACC integration is read-only from Speckle to ACC.
+  <Accordion title="Does Speckle change data in Forma Data Management / ACC?">
+    No. The integration is read-only from Speckle to Autodesk cloud sources.
 
     Speckle syncs and processes data for Speckle-side use, but does not modify
-    the original ACC files.
+    the original cloud-hosted files.
   </Accordion>
-  <Accordion title="Whose permissions do ACC syncs use?">
-    ACC syncs run using the account that set up the connection.
+  <Accordion title="Whose permissions do Forma Data Management / ACC syncs use?">
+    Cloud syncs run using the account that set up the connection.
 
     In practice, access is limited to what that account is already allowed to
-    view in ACC. To reduce risk, use a dedicated least-privilege ACC account for
+    view in Autodesk Forma Data Management (ACC). To reduce risk, use a dedicated least-privilege Autodesk account for
     production syncs.
   </Accordion>
 </AccordionGroup>

--- a/workspaces/projects.mdx
+++ b/workspaces/projects.mdx
@@ -263,14 +263,14 @@ For dashboard setup and usage details, see [Intelligence Dashboards](/analytics/
 
 ### Cloud integrations (ACC)
 
-Open **ACC** in the project sidebar to explore connected hubs and systems you can
+Open **ACC** (Autodesk Forma Data Management; sidebar labels may still say ACC) in the project sidebar to explore connected hubs and systems you can
 access from this project.
 
 Use this area to select source locations and set up syncs into the project.
 Synced data is then available as Speckle models in the project, alongside models created through connector publishing.
-Keep detailed ACC setup, permissions, and sync-step guidance in the dedicated ACC documentation.
+Keep detailed setup, permissions, and sync-step guidance in the dedicated Forma Data Management documentation.
 
-For ACC setup details, see [Autodesk Construction Cloud (ACC)](/connectors/cloud-integrations/acc).
+For setup details, see [Autodesk Forma Data Management (ACC)](/connectors/cloud-integrations/acc).
 
 Together, activity, quality, issue, integration, and reporting surfaces give an at-a-glance view of project pulse.
 These signals are surfaced on the project home page so teams can assess project pulse without digging through multiple pages.


### PR DESCRIPTION
Updates all references to Autodesk Construction Cloud, now referred to as Autodesk Forma Data Management.   Retains ACC everywhere.
Improves integration instructions and governance documentation to align with this change.