### PR TITLE
Add material textures limitation note to FAQs

### DIFF
--- a/snippets/connectors/load-faq.mdx
+++ b/snippets/connectors/load-faq.mdx
@@ -1,7 +1,11 @@
+import MaterialTexturesLimitation from '/snippets/connectors/material-textures-limitation.mdx';
+
 <Accordion title="Why are some objects that I loaded missing from my model?">
     After you load a Speckle model, click on the **Report** button to see any errors that may have occurred. 
     Click on any item in the report to highlight that item in your application. Some objects may not be supported for loading in {app}.
 </Accordion>
+
+<MaterialTexturesLimitation />
 
 <Accordion title="Why can't I select a project in the UI—it's disabled?">
     This happens when you don't have permissions to load a project. Contact the project owner to change your role.

--- a/snippets/connectors/material-textures-limitation.mdx
+++ b/snippets/connectors/material-textures-limitation.mdx
@@ -1,0 +1,7 @@
+<Accordion title="Are bitmap or image-based material textures supported?">
+  **Image texture files are not supported.** Speckle does **not** transfer bitmaps or other image maps (such as JPG or PNG files) embedded in materials from the source application.
+
+  Speckle **does** carry [PBR-style material data](/developers/sdks/python/guides/understanding-speckle-mesh#render-materials) in general—where a connector maps to it, materials can include properties such as base colour, opacity, metalness, roughness, and emissive colour. That is not the same as shipping texture images: you get numeric material parameters, not image assets used for wood grain, brick patterns, and similar in the authoring tool.
+
+  Different materials can still appear separately in the destination with distinct colours and PBR fields. What you see may look closer to a consistent shaded or PBR preview than to the full render-appearance with image maps in tools such as Revit or SketchUp. To use image textures in your target application, apply or remap them locally after you publish or load.
+</Accordion>

--- a/snippets/connectors/publish-faq.mdx
+++ b/snippets/connectors/publish-faq.mdx
@@ -1,6 +1,10 @@
+import MaterialTexturesLimitation from '/snippets/connectors/material-textures-limitation.mdx';
+
 <Accordion title="Why does my model have the wrong colors in the web browser viewer?">
 In the viewer, select the **View Modes** button in the side bar, and switch the view mode to **Shaded**. If you still don't see your object colors, let us know in our [Community Forum](https://speckle.community/c/help)
 </Accordion>
+
+<MaterialTexturesLimitation />
 
 <Accordion title="Why are some objects that I published missing from my model?">
 After you publish a Speckle model, click on the **Report** button to see any errors that may have occurred. 


### PR DESCRIPTION
Introduces a new section about material textures limitation to the FAQ documents, explaining the non-support for image textures like JPG or PNG, and providing guidance on how to handle material data within Speckle connectors.