### PR TITLE
chore: add Python 3.14 support

### DIFF
--- a/developers/sdks/python/getting-started/installation.mdx
+++ b/developers/sdks/python/getting-started/installation.mdx
@@ -7,7 +7,7 @@ description: "Install specklepy and set up your Python environment"
 
 specklepy requires:
 
-- **Python 3.10 or higher** (Python 3.10, 3.11, 3.12, 3.13 supported)
+- **Python 3.10 or higher** (Python 3.10, 3.11, 3.12, 3.13, 3.14 supported)
 
 <Check>
 specklepy works on Windows, macOS, and Linux.


### PR DESCRIPTION
Extend compatibility to include Python 3.14.
