### PR TITLE
feat(rvt, acad, c3d): 2022 out, 2027 in

### DIFF
--- a/connectors/autocad.mdx
+++ b/connectors/autocad.mdx
@@ -15,9 +15,13 @@ import LoadFaq from "/snippets/connectors/load-faq.mdx";
 
 <Versions
   app="AutoCAD"
-  versions="2022, 2023, 2024, 2025, & 2026"
+  versions="2023, 2024, 2025, 2026, & 2027"
   os="Windows"
 />
+
+<Warning>
+  **2022 support has ended.** If you use AutoCAD 2022, use connector version 3.21.0 or upgrade AutoCAD to a supported version. For more context, see [this forum post](https://speckle.community/t/adsk-2022-support-ending-with-the-release-of-2027-connectors/22094).
+</Warning>
 
 ## Setup
 
@@ -92,19 +96,3 @@ import LoadFaq from "/snippets/connectors/load-faq.mdx";
   <LoadFaq app="AutoCAD" />
 
 </AccordionGroup>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/connectors/civil3d.mdx
+++ b/connectors/civil3d.mdx
@@ -15,9 +15,13 @@ import LoadFaq from '/snippets/connectors/load-faq.mdx';
 
 <Versions
   app="Civil 3D"
-  versions="2022, 2023, 2024, 2025, & 2026"
+  versions="2023, 2024, 2025, 2026, & 2027"
   os="Windows"
 />
+
+<Warning>
+  **2022 support has ended.** If you use Civil 3D 2022, use connector version 3.21.0 or upgrade Civil 3D to a supported version. For more context, see [this forum post](https://speckle.community/t/adsk-2022-support-ending-with-the-release-of-2027-connectors/22094).
+</Warning>
 
 ## Setup
 

--- a/connectors/navisworks.mdx
+++ b/connectors/navisworks.mdx
@@ -14,7 +14,7 @@ import NoLoad from "/snippets/connectors/no-load.mdx";
 
 <Versions
   app="Navisworks"
-  versions="2020, 2021, 2022, 2023, 2024, 2025 & 2026"
+  versions="2020, 2021, 2022, 2023, 2024, 2025, 2026, & 2027"
   os="Windows"
 />
 

--- a/connectors/revit/revit.mdx
+++ b/connectors/revit/revit.mdx
@@ -14,7 +14,11 @@ import Load from '/snippets/connectors/load.mdx';
 import LoadFaq from '/snippets/connectors/load-faq.mdx';
 import CoordinationWorkflowRevitBenefit from '/snippets/connectors/coordination-workflow-revit-benefit.mdx';
 
-<Versions app="Revit" versions="2022, 2023, 2024, 2025 & 🆕2026" os="Windows" />
+<Versions app="Revit" versions="2023, 2024, 2025, 2026, & 2027" os="Windows" />
+
+<Warning>
+  **2022 support has ended.** If you use Revit 2022, use connector version 3.21.0 or upgrade Revit to a supported version. For more context, see [this forum post](https://speckle.community/t/adsk-2022-support-ending-with-the-release-of-2027-connectors/22094).
+</Warning>
 
 ## Setup
 


### PR DESCRIPTION
<img width="783" height="351" alt="image" src="https://github.com/user-attachments/assets/8664bd86-20ca-489d-b8a9-6a491c02c7f9" />
