### PR TITLE
Fix for manual install docs

### DIFF
--- a/connectors/manual-installation/blender.mdx
+++ b/connectors/manual-installation/blender.mdx
@@ -4,8 +4,6 @@ description: "Manual installation instructions for Speckle Blender connector via
 noindex: true
 ---
 
-import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';
-
 <Warning>
   **This guide is for IT administrators only.** If you are a regular user, see our [Blender installation guide](/connectors/blender) instead.
 </Warning>

--- a/connectors/manual-installation/desktop-services.mdx
+++ b/connectors/manual-installation/desktop-services.mdx
@@ -4,8 +4,6 @@ description: "Manual installation instructions for Speckle Desktop Services via 
 noindex: true
 ---
 
-import DisableUpdateNotifications from '/snippets/connectors/disable-update-notifications.mdx';
-
 <Warning>
   **This guide is for IT administrators only.** If you are a regular user, see our [standard installation guide](/connectors/installation) instead.
 </Warning>
@@ -37,10 +35,6 @@ Follow the same steps as the single user install, but use these locations instea
 
 - **Program files**: `%ProgramFiles%\Speckle\Desktop Services\`
 - **Startup folder**: `%ProgramData%\Microsoft\Windows\Start Menu\Programs\StartUp\`
-
-## After installation
-
-**Disable update notifications**: <DisableUpdateNotifications />
 
 ## Uninstall Desktop Services
 

--- a/docs.json
+++ b/docs.json
@@ -61,6 +61,10 @@
       "destination": "/connectors/manual-installation/teklastructures"
     },
     {
+      "source": "/connectors/manual-installation/rhino",
+      "destination": "/connectors/manual-installation/rhino-grasshopper"
+    },
+    {
       "source": "/developers/building-connectors",
       "destination": "/developers/building-integrations"
     },


### PR DESCRIPTION
- Add redirect for `/connectors/manual-installation/rhino` -> `/connectors/manual-installation/rhino-grasshopper` to fix cross link from releases.speckle.systems
- Fix issue with desktop-service page due to import