### PR TITLE
Update report severity options in checks.mdx

### DIFF
--- a/analytics/data-validation/checks.mdx
+++ b/analytics/data-validation/checks.mdx
@@ -95,7 +95,7 @@ Each rule is filters plus one assertion.
 | Property path   | Target property (`category`, `baseline.length`, `parameters.Width.value`)   |
 | Predicate       | Comparison operator (**Equals**, **Exists**, **Matches pattern**, and more) |
 | Value           | Reference value for the predicate                                           |
-| Report severity | `ERROR`, `WARNING`, or `INFO`                                               |
+| Report severity | `ERROR` or `INFO`                                                           |
 | Message         | Human-facing explanation for failed outcomes                                |
 
 ## Default scope


### PR DESCRIPTION
Removed 'WARNING' option from report severity.