### PR TITLE
Prioritizes Script-First Approach in Developer Docs

### DIFF
--- a/.universal-ai-config/instructions/docs-authoring.md
+++ b/.universal-ai-config/instructions/docs-authoring.md
@@ -16,6 +16,7 @@ This project uses **universal-ai-config** for canonical doc rules. Generated ins
 - **Plain language**: approachable, precise, no jargon; imperative steps.
 - **Honest guardrails**: call out limitations, known issues, version differences.
 - **Connectors are a subset**: everyone uses the web app; not everyone uses connectors.
+- **Developer docs: scripts first**: default SDK/API examples for citizen developers and AEC hackers (standalone scripts, notebooks, small automations). Connector and add-in development is secondary — see [Docs Agent — Persona and Audience](docs-persona-audience.md) § Developer Docs Audience Hierarchy.
 
 ## Global Authoring Rules
 

--- a/.universal-ai-config/instructions/docs-persona-audience.md
+++ b/.universal-ai-config/instructions/docs-persona-audience.md
@@ -11,13 +11,61 @@ Match the audience to the doc type. Write for the person viewing the docs.
 
 | Doc type | Audience | Intent |
 | --- | --- | --- |
-| **Developer docs** | Developers | Build, integrate, extend, debug |
+| **Developer docs** | Developers (see hierarchy below) | Build, integrate, extend, debug |
 | **User guides** | Users | Use the product, publish, load, share, view |
 | **IT support docs** | IT teams supporting Speckle deployment | Deploy, configure, troubleshoot, support users |
 
 - Developer docs: env vars, APIs, SDKs, connectors, server setup.
 - User guides: workspaces, connectors (publish/load), 3D viewer, sharing.
 - IT support docs: deployment, admin support mode, workspace admin flows, enterprise features.
+
+## Developer Docs Audience Hierarchy
+
+Within **developer docs**, assume the reader is most often a **citizen developer** or **AEC hacker** — not a full-time platform engineer building a maintained host-application integration.
+
+### Primary audience (default for SDK and API docs)
+
+Practitioners who write **short-lived code** to move AEC data through Speckle while staying inside tools they already use:
+
+- Standalone scripts and console apps
+- Notebook cells (polyglot / Jupyter / IDE notebooks)
+- Grasshopper or Dynamo C# components
+- Small automations that **augment** existing software (Revit, Rhino, Excel, internal tools) — not replace it
+
+**Intent:** get data in or out of Speckle quickly; minimal ceremony; visible outcome on day zero.
+
+**Write for them by default:**
+
+- Lead with PAT auth, env vars, and the shortest working send/receive path.
+- Frame advanced setup (dependency injection, ingestion pipelines, proxy unpacking) as **optional depth**, not prerequisites.
+- Label connector-only or host-integration content **before** code blocks (`<Warning>` / `<Info>`), not buried at the end.
+- Prefer examples that fit one file or one notebook cell unless the page is explicitly connector-oriented.
+
+### Secondary audience (included, not default)
+
+Teams building **maintained host-application integrations**:
+
+- Production desktop connectors (Revit, Rhino, AutoCAD, and similar add-ins)
+- Long-lived services and ASP.NET apps sharing a DI container with the SDK
+- Connector-scale upload paths (`SendPipeline`, model ingestion, continuous traversal)
+
+**Intent:** production reliability, progress reporting, server capability detection, cooperative cancellation.
+
+**Write for them in dedicated pages or clearly marked sections** — same SDK, deeper paths. Do not let connector patterns become the default story on introduction, quickstart, or overview pages.
+
+### Persona check (before publishing SDK content)
+
+1. **Would a script writer need this on day one?** If no → later section, advanced guide, or connector track.
+2. **Does the first example assume DI literacy or connector internals?** If yes → add a script-first path or link to [Scripts and Notebooks](/developers/sdks/dotnet/getting-started/scripts-and-notebooks) (.NET) / specklepy quickstart (Python).
+3. **Is connector-only content labeled at the top?** If no → add a warning before the first code sample.
+
+### Terminology
+
+| Term | Meaning in docs |
+| --- | --- |
+| **Citizen developer / AEC hacker** | Primary reader; scripts and small automations beside existing AEC tools |
+| **Augmenting existing software** | Speckle beside the host app — not building a new host or full connector product |
+| **Connector / add-in development** | Secondary reader; maintained host-application integration (least likely entry path, must remain documented) |
 
 ## IT Support Audience Hierarchy
 

--- a/.universal-ai-config/instructions/docs-sdk-dotnet.md
+++ b/.universal-ai-config/instructions/docs-sdk-dotnet.md
@@ -1,0 +1,63 @@
+---
+description: Speckle.Sdk (.NET) docs — scripts-first audience, bootstrap boilerplate, connector content secondary
+globs: ["developers/sdks/dotnet/**"]
+---
+
+# Speckle.Sdk (.NET) Documentation
+
+Applies when creating or editing pages under `developers/sdks/dotnet/`.
+
+## Audience (scripts first)
+
+Primary reader: **citizen developer / AEC hacker** — Grasshopper C#, polyglot notebook cell, one-off script augmenting existing AEC software.
+
+Secondary reader: **connector / add-in author** — production host-application integration. Document thoroughly but do not let this persona own introduction, quickstart, or default examples.
+
+Full persona rules: see **Developer Docs Audience Hierarchy** in `docs-persona-audience.md`.
+
+## Entry points by reader
+
+| Reader | Direct them to |
+| --- | --- |
+| Script, notebook, GH C# | [Scripts and Notebooks](/developers/sdks/dotnet/getting-started/scripts-and-notebooks) |
+| First full walkthrough | [Quickstart](/developers/sdks/dotnet/getting-started/quickstart) |
+| Connector / large host-app send | [Building Connector-Scale Sends](/developers/sdks/dotnet/guides/building-connector-scale-sends), [Dependency Injection](/developers/sdks/dotnet/concepts/dependency-injection) |
+
+Nav order in `docs.json`: prefer **Scripts and Notebooks** before connector-oriented guides when adding Getting Started pages.
+
+## Bootstrap vs dependency injection
+
+- Speckle.Sdk has **no** specklepy-style import-and-go. A one-time `AddSpeckleSdk` bootstrap is required.
+- **Do not** present DI as a skill readers must learn for scripts. Call it **boilerplate** — copy once, resolve `IOperations` / `IClientFactory`, ignore container design.
+- **Do not** open introduction or quickstart with "Dependency Injection by Design" as a selling point.
+
+## Default send/receive path for examples
+
+| Reader | Prefer in examples |
+| --- | --- |
+| Scripts, notebooks, quick wins | `Send2` / `Receive2` (URL + project id + token; no `IServerTransportFactory`) |
+| Quickstart tour (transport teaching) | `Send` / `Receive` with `IServerTransportFactory` — acceptable when the page is explicitly a full walkthrough |
+| Connectors only | `SendPipeline` + model ingestion — never the default on non-connector pages |
+
+## Connector-only content (label upfront)
+
+These topics are **secondary** — mark with `<Warning>` or `<Info>` at the top of the page or section:
+
+- `SendPipeline`, `ISendPipelineFactory`, model ingestion lifecycle
+- `client.Ingestion.*` as part of a script workflow (ingestion completion semantics differ for packfile vs manual paths)
+- `IRootContinuousTraversalBuilder`, packfile send, ingestion progress subscriptions
+- Deep `GraphTraversal` / proxy unpacking (unless page is explicitly about receiving connector-produced data)
+
+## Cross-links
+
+- Compare to specklepy where helpful — Python readers expect import-and-go; .NET readers need the bootstrap preamble explained once.
+- Link to [speckle-sharp-connectors](https://github.com/specklesystems/speckle-sharp-connectors) only on connector-scale pages, not on every SDK overview.
+
+## Authoring checklist (.NET SDK page)
+
+Before completing an edit:
+
+1. First code sample achievable without connector knowledge?
+2. Connector-only sections warned before code?
+3. Script path linked where bootstrap or `GetRequiredService` appears?
+4. `pnpm valid` and `pnpm check-links` run from `speckle-docs-NEW` after substantive changes?

--- a/.universal-ai-config/instructions/docs-sdk-python.md
+++ b/.universal-ai-config/instructions/docs-sdk-python.md
@@ -1,0 +1,31 @@
+---
+description: specklepy docs — scripts-first audience; connector patterns secondary
+globs: ["developers/sdks/python/**"]
+---
+
+# specklepy Documentation
+
+Applies when creating or editing pages under `developers/sdks/python/`.
+
+## Audience (scripts first)
+
+Primary reader: **citizen developer / AEC hacker** — notebook, script, small automation beside existing AEC tools.
+
+Secondary reader: maintained integrations and connector-adjacent tooling. specklepy is already import-and-go friendly; **do not** over-index connector deployment patterns on introduction or quickstart pages.
+
+Full persona rules: see **Developer Docs Audience Hierarchy** in `docs-persona-audience.md`.
+
+## Default examples
+
+- Lead with `SpeckleClient`, `operations.send` / `operations.receive`, and PAT or `get_default_account()`.
+- Keep examples copy-pasteable in one script or notebook cell.
+- Put advanced topics (custom transports at scale, connector-specific object graphs, proxy unpacking) in guides — not the first screen.
+
+## Parity with .NET docs
+
+When both SDKs document the same concept:
+
+- specklepy: emphasize simplicity (direct imports).
+- .NET: emphasize one-time bootstrap + `Send2`/`Receive2` for script parity — link to [Scripts and Notebooks](/developers/sdks/dotnet/getting-started/scripts-and-notebooks), not DI concept pages.
+
+Do not let .NET connector docs set the tone for specklepy pages unless the workflow is genuinely connector-only.


### PR DESCRIPTION
Refines developer documentation to focus on scripts and small automations for citizen developers and AEC hackers, adding specific guidelines for .NET and Python SDKs. Updates audience hierarchy and improves clarity on whom the docs are tailored for, ensuring a more accessible and direct user experience.