### PR TITLE
ci: make validate and broken-links blocking (Phase 2a)

### DIFF
--- a/.github/workflows/docs-pr-checks.yml
+++ b/.github/workflows/docs-pr-checks.yml
@@ -1,12 +1,8 @@
-# Phase 1: report-only docs quality checks on pull requests.
-# Jobs run in parallel. Each uses continue-on-error so debt does not block merge.
-# Phase 2: clear debt per job, drop continue-on-error, require jobs in branch
-# protection (prefer: validate + links first; then format-lint; a11y last).
+# Phase 2a: validate + broken-links are blocking. Format-lint and a11y stay
+# report-only until markdownlint debt PRs land and format-lint is required.
 #
-# Known full-repo debt:
-# - format-lint full-repo: large Prettier / markdownlint backlog (CI uses changed files)
-# - a11y: expect findings until alt/contrast debt is cleared
-# validate + core links were green; redirects/snippets/a11y are new report-only surface.
+# Branch protection: require status checks named "Mintlify validate" and
+# "Broken links" (see scripts/enable-required-pr-checks.sh).
 
 name: Docs PR checks
 
@@ -30,6 +26,7 @@ on:
       - 'lint-staged.config.mjs'
       - 'scripts/format-check-changed.sh'
       - 'scripts/lint-md-changed.sh'
+      - 'scripts/enable-required-pr-checks.sh'
       - '.github/workflows/docs-pr-checks.yml'
       - '.github/workflows/docs-scheduled-checks.yml'
 
@@ -79,14 +76,13 @@ jobs:
             echo '## Format and lint (changed files)'
             echo ''
             echo 'Prettier + markdownlint on files changed in this PR only.'
-            echo 'Report-only in Phase 1 (`continue-on-error` on this job).'
+            echo 'Still report-only until markdownlint debt PRs land.'
           } >> "$GITHUB_STEP_SUMMARY"
 
   validate:
     name: Mintlify validate
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
 
     steps:
       - name: Checkout
@@ -113,14 +109,13 @@ jobs:
           {
             echo '## Mintlify validate (full site)'
             echo ''
-            echo 'Report-only in Phase 1 until this job is made required.'
+            echo 'Blocking. Require this check in branch protection for `main`.'
           } >> "$GITHUB_STEP_SUMMARY"
 
   broken-links:
     name: Broken links
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    continue-on-error: true
 
     steps:
       - name: Checkout
@@ -148,8 +143,8 @@ jobs:
             echo '## Broken links (full site)'
             echo ''
             echo 'Anchors + docs.json redirects + links inside Snippet components.'
-            echo 'External URLs are checked on the scheduled workflow, not on PRs.'
-            echo 'Report-only in Phase 1 until this job is made required.'
+            echo 'Blocking. Require this check in branch protection for `main`.'
+            echo 'External URLs stay on the scheduled workflow.'
           } >> "$GITHUB_STEP_SUMMARY"
 
   accessibility:
@@ -183,5 +178,5 @@ jobs:
           {
             echo '## Accessibility (full site)'
             echo ''
-            echo '`mint a11y` — alt text and contrast. Expect debt; report-only in Phase 1.'
+            echo '`mint a11y` — still report-only (Phase 2c).'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -69,12 +69,20 @@ Connector pages are naturally more detailed because they must cover multiple hos
 
 ### PR checks (CI)
 
-Pull requests run [`.github/workflows/docs-pr-checks.yml`](.github/workflows/docs-pr-checks.yml) as **four parallel jobs** (each report-only / `continue-on-error` for now):
+Pull requests run [`.github/workflows/docs-pr-checks.yml`](.github/workflows/docs-pr-checks.yml) as **four parallel jobs**:
 
-- **Format and lint** — `pnpm format:check:changed` + `pnpm lint:md:changed` (PR files only)
-- **Mintlify validate** — `pnpm valid` (full site)
-- **Broken links** — `pnpm check-links` (anchors + redirects + Snippet links; full site)
-- **Accessibility** — `pnpm check:a11y` (`mint a11y`; full site)
+- **Format and lint** — `pnpm format:check:changed` + `pnpm lint:md:changed` (PR files only; still report-only until lint debt PRs land)
+- **Mintlify validate** — `pnpm valid` (full site; **blocking**)
+- **Broken links** — `pnpm check-links` (anchors + redirects + Snippet links; full site; **blocking**)
+- **Accessibility** — `pnpm check:a11y` (`mint a11y`; full site; report-only)
+
+After merging this Phase 2a change, require the blocking jobs on `main`:
+
+```bash
+bash scripts/enable-required-pr-checks.sh
+```
+
+(Needs `gh auth login` with repo admin.) Or set branch protection manually to require status checks **Mintlify validate** and **Broken links**.
 
 Scheduled / manual ([`.github/workflows/docs-scheduled-checks.yml`](.github/workflows/docs-scheduled-checks.yml)):
 
@@ -86,7 +94,7 @@ Scheduled / manual ([`.github/workflows/docs-scheduled-checks.yml`](.github/work
 After `pnpm install`, Husky installs a **pre-commit** hook that runs [lint-staged](https://github.com/lint-staged/lint-staged) on staged files only:
 
 - **Prettier** `--write` — blocking (must format cleanly)
-- **markdownlint** — Phase 1 **report-only** (prints findings, does not block the commit). Staging many migrated pages otherwise fails on backlog MD036/MD001/etc. Same spirit as CI `continue-on-error` on Format and lint.
+- **markdownlint** — report-only until format-lint is required in CI (prints findings, does not block the commit)
 
 Does **not** run validate, links, or a11y. Skip once: `git commit --no-verify`.
 
@@ -110,7 +118,7 @@ pnpm format
 pnpm lint:md:fix
 ```
 
-**Phase 2:** clear debt per job, drop that job’s `continue-on-error`, then require jobs in branch protection one at a time (validate + links first; format-lint next; a11y last).
+**Phase 2b+:** clear markdownlint debt (MD060 → MD036 → leftovers), then drop `continue-on-error` on Format and lint and require that job; a11y last.
 
 ### Generating universal-ai-config instructions
 

--- a/scripts/enable-required-pr-checks.sh
+++ b/scripts/enable-required-pr-checks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Require Docs PR check jobs on main (Phase 2a: validate + broken links).
+# Needs: gh auth login with admin on specklesystems/speckle-docs-NEW
+#
+# Usage:
+#   bash scripts/enable-required-pr-checks.sh
+#   REPO=specklesystems/speckle-docs-NEW BRANCH=main bash scripts/enable-required-pr-checks.sh
+set -euo pipefail
+
+REPO="${REPO:-specklesystems/speckle-docs-NEW}"
+BRANCH="${BRANCH:-main}"
+
+echo "Updating branch protection on ${REPO}@${BRANCH}"
+echo "Required status checks: Mintlify validate, Broken links"
+
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/${REPO}/branches/${BRANCH}/protection" \
+  --input - <<EOF
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Mintlify validate", "Broken links"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+
+echo "Done. Confirm in GitHub → Settings → Branches → ${BRANCH}."


### PR DESCRIPTION
Drop continue-on-error on Mintlify validate and Broken links. Keep format-lint and a11y report-only. Add enable-required-pr-checks.sh for branch protection.