### PR TITLE
chore: convert bold-only lines to plain Labels: (MD036)

### DIFF
--- a/3d-viewer/issues.mdx
+++ b/3d-viewer/issues.mdx
@@ -162,8 +162,7 @@ Access all issues for the currently loaded models from the Issues panel in the v
 
 By default, issues marked as **Done** are hidden to keep the list focused on active work.
 
-**Filter issues by:**
-
+Filter issues by:
 - Status
 - Assignee
 - Due date

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Canonical doc rules for AI assistants live in `.universal-ai-config/instructions
 
   We deliberately describe this section as **Publishing & Loading** rather than "Connectors." This keeps the docs user-first and purpose-driven: users think in terms of publishing data into Speckle or loading it into another tool, not in terms of underlying plumbing. It frames the outcome (why) rather than the mechanism (how).
 
-  **Connector Documentation Structure:**
+  Connector Documentation Structure:
   - Use main page sections for step-by-step guides (e.g., "Setting up Data Gateway")
   - Use accordions for FAQs and troubleshooting questions
   - Import and use standard components: `<Setup>`, `<Load>`, `<Publish>`, `<SetupFaq>`, `<LoadFaq>`, `<PublishFaq>`
@@ -38,7 +38,7 @@ Canonical doc rules for AI assistants live in `.universal-ai-config/instructions
 - **Best Practices**: Principles and recommendations that help users avoid pitfalls and make good choices. They should read as guidance, not rigid rules.
 - **Tips & Tricks**: Small, optional enhancements or shortcuts. Presented as quick callouts, not workflows, and always optional to the main path.
 
-**When to use accordions vs. main sections:**
+When to use accordions vs. main sections:
 
 - **Accordions**: For FAQs, troubleshooting questions, and quick reference information
 - **Main sections**: For step-by-step guides, detailed procedures, and comprehensive workflows

--- a/analytics/data-validation/checks.mdx
+++ b/analytics/data-validation/checks.mdx
@@ -5,7 +5,7 @@ description: 'Author and run Validation Checks with WHERE/CHECK logic in Data Va
 ---
 
 <Warning>
-  **Current limitation**
+  Current limitation:
 
 In v0, after creation you can rename a check only; scope, rule list, and predicates stay
 frozen. For different behaviour, create a new check.
@@ -20,7 +20,7 @@ Use this page for **Validation Check** authoring and execution.
 </Info>
 
 <Note>
-  **v0 release behavior (available today):**
+  v0 release behavior (available today):
   checks can be defined and run against all models in a project. Editing an existing
   check is currently limited to its name; scope and rules are not yet editable after
   creation.

--- a/beta/parameter-updater.mdx
+++ b/beta/parameter-updater.mdx
@@ -145,8 +145,7 @@ For beta testing, focus on:
 
 ## Troubleshooting
 
-**"Your token does not have the required scope for this action"**
-
+"Your token does not have the required scope for this action":
 This means the connector token is missing the `issues:write` scope needed to
 resolve the issue after applying changes. The parameter updates themselves will
 still have been applied. To fix it, go to **Manage Accounts** in the connector,

--- a/classic/3d-viewer/issues.mdx
+++ b/classic/3d-viewer/issues.mdx
@@ -141,8 +141,7 @@ Access all issues for the currently loaded models from the Issues panel in the v
 
 By default, issues marked as **Done** are hidden to keep the list focused on active work.
 
-**Filter issues by:**
-
+Filter issues by:
 - Status
 - Assignee
 - Due date
@@ -291,8 +290,7 @@ Issue permissions depend on your project role and whether you created or are ass
 | **Comment on issues**                                 | Yes                                | Yes                                | Yes           | Yes – if enabled on project |
 | **Edit comments**                                     | No                                 | No                                 | No            | No                          |
 
-**Important notes:**
-
+Important notes:
 - Nobody can edit issue comments after posting, including project owners
 - You must have a Speckle account to create issues or comment, even in public projects
 - Anyone in the workspace can be assigned to an issue, regardless of their project role

--- a/classic/workspaces/roles-and-seats.mdx
+++ b/classic/workspaces/roles-and-seats.mdx
@@ -148,10 +148,8 @@ Seats control **permissions**, not billing. Plans are based on the total number 
 import ProjectRolesFAQ from "/snippets/clasic/faqs/project-roles.mdx";
 import WorkspaceRolesFAQ from "/snippets/faqs/workspace-roles.mdx";
 
-**Project roles**
-
+Project roles:
 <ProjectRolesFAQ />
 
-**Workspace roles**
-
+Workspace roles:
 <WorkspaceRolesFAQ />

--- a/connectors/archicad.mdx
+++ b/connectors/archicad.mdx
@@ -88,7 +88,7 @@ import LoadFaq from "/snippets/connectors/load-faq.mdx";
 
     <Accordion title="Publishing my model takes a long time. Can I speed it up?">
         Yes. If element properties aren't required, you can disable property extraction to speed up the publishing process.
-        **To disable property extraction**
+        To disable property extraction:
         1. Open the **Send Settings**.
         2. Turn off the **Include Object Properties** option.
         <Note> Disabling property extraction can significantly reduce publish time. </Note>

--- a/connectors/connector-configuration.mdx
+++ b/connectors/connector-configuration.mdx
@@ -5,10 +5,10 @@ noindex: true
 ---
 
 <Note>
-  **This documentation is for Speckle Enterprise customers only.**
+  This documentation is for Speckle Enterprise customers only.:
 
-  **Please note that these configuration are not yet supported in all connectors.<br/>
-  Please contact your Speckle representative for more information.**
+  Please note that these configuration are not yet supported in all connectors.<br/>
+  Please contact your Speckle representative for more information.:
 </Note>
 
 ### Disable Update Notifications

--- a/connectors/direct-uploads/introduction.mdx
+++ b/connectors/direct-uploads/introduction.mdx
@@ -136,7 +136,7 @@ IFC files are converted to Speckle format with support for attributes, property 
 <Info>**Supported versions:** IFC2x3, IFC4, IFC4x1, IFC4x2, IFC4x3</Info>
 
 <Check>
-  **Features**
+  Features:
 
 - Element and element type attributes
 - Property sets
@@ -146,7 +146,7 @@ IFC files are converted to Speckle format with support for attributes, property 
 </Check>
 
 <Info>
-  **Known limitations**
+  Known limitations:
 
 - IFC2x2_FINAL and Release Candidate versions aren't supported
 - Alternative formats such as XML, ZIP, and databases aren't supported
@@ -164,7 +164,7 @@ Rhino files maintain geometry and layer structure when uploaded.
 </Note>
 
 <Info>
-  **Known limitations**
+  Known limitations:
 
 - Rhino 9 files aren't supported
 - Dynamic text isn't supported
@@ -181,7 +181,7 @@ SketchUp models are converted with geometry and basic organization preserved.
 </Note>
 
 <Info>
-  **Known limitations**
+  Known limitations:
 
 - Attributes aren't imported
 - Dynamic components may not transfer correctly
@@ -198,7 +198,7 @@ Upload AutoCAD drawing files directly. Results may vary depending on file comple
 </Note>
 
 <Info>
-  **Known limitations**
+  Known limitations:
 
 - Large files may take longer to process
 - Dynamic text isn't supported
@@ -210,7 +210,7 @@ Upload AutoCAD drawing files directly. Results may vary depending on file comple
 OBJ files are converted with geometry preserved.
 
 <Info>
-  **Known limitations**
+  Known limitations:
 
 - Materials aren't supported
 

--- a/connectors/grasshopper/grasshopper-recommendations.mdx
+++ b/connectors/grasshopper/grasshopper-recommendations.mdx
@@ -13,8 +13,7 @@ Grasshopper params do not have any persistent GUID (Grasshopper 8+ model params 
 
 Define custom sets of components that capture your project delivery standards and conventions when working as part of a team on a project, or as a collaborator across multiple projects. Save your Speckle Grasshopper nodes as User Objects and share your custom nodes with your team to make sure they are following naming conventions for layers, working with predefined property sets during analysis, and more.
 
-**How to create a User Object**
-
+How to create a User Object:
 1. Customize your Speckle node (or cluster of nodes) to your project conventions
 2. Select **File** > **Create User Object** in the Grasshopper menu.
 3. Fill in each field in the pop-up form to describe your User Node and project.

--- a/connectors/manual-installation/autocad-civil3d.mdx
+++ b/connectors/manual-installation/autocad-civil3d.mdx
@@ -8,7 +8,7 @@ description: "Manual installation instructions for Speckle AutoCAD and Civil 3D 
 </Warning>
 
 <Note>
-  **This guide is not yet available.**
+  This guide is not yet available.:
 </Note>
 
 

--- a/connectors/manual-installation/desktop-services.mdx
+++ b/connectors/manual-installation/desktop-services.mdx
@@ -15,7 +15,7 @@ Not all connectors require the desktop service. Check the installation instructi
 For the connectors that require it, the Desktop Service should be running at all times. We recommend setting it to launch at startup so it's always available.
 
 <Warning>
-  **Updating from an older version?** 
+  Updating from an older version?:
   
   Make sure Desktop Services isn't running before you install. After installation, restart the service.
 </Warning>

--- a/connectors/manual-installation/etabs.mdx
+++ b/connectors/manual-installation/etabs.mdx
@@ -33,8 +33,7 @@ For versions ≥ 3.17.2; the desktop service is not required.
   Replace `{VERSION}` with your ETABS version in all paths and settings.
 </Info>
 
-**Example configuration for ETABS 22:**
-
+Example configuration for ETABS 22:
 ```ini
 [PlugIn]
 NumberPlugIns=1

--- a/connectors/power-bi/gateway.mdx
+++ b/connectors/power-bi/gateway.mdx
@@ -197,7 +197,7 @@ Data gateways enable scheduled refresh of your Power BI reports, ensuring your S
             <img src="/images/connectors/powerbi/dg unknown function.png" alt="Unknown function error" />
         </Frame>
 
-        **To troubleshoot this error:**
+        To troubleshoot this error:
 
         1. Verify the gateway appears in Power BI service under **Settings** > **Manage connections and gateways** > **On-premises data gateways**.
 
@@ -216,7 +216,7 @@ Data gateways enable scheduled refresh of your Power BI reports, ensuring your S
 
         The report should now work properly.
 
-        **Why this works**
+        Why this works:
 
         Custom connectors require a dataset with verified connectors to be published first. After you publish a dataset with standard connectors, custom connectors will work with the data gateway. You only need to do this once per data gateway.
     </Accordion>

--- a/connectors/power-bi/power-bi.mdx
+++ b/connectors/power-bi/power-bi.mdx
@@ -217,7 +217,7 @@ Speckle's connection to Power BI consists of two parts.
     <Accordion title="Why do I get a 'Permission denied' error?">
         This error usually means you don’t have the required permissions to load the model.  
 
-            **Steps to fix it:**
+            Steps to fix it:
 
             1. Verify that you have been granted access to the model.  
                 - If not, contact the project owner and request the necessary permissions.  

--- a/connectors/revit/revit.mdx
+++ b/connectors/revit/revit.mdx
@@ -178,7 +178,7 @@ import CoordinationWorkflowRevitBenefit from '/snippets/connectors/coordination-
       Yes. When you load a model that contains views, they are automatically
       created as **3D views** in Revit — no extra steps needed.
 
-      **Notes:**
+      Notes:
       - If a 3D view with the same name already exists in Revit, it will be skipped
         and not overwritten.
       - Views published from other connectors (e.g., Rhino named views) are also

--- a/connectors/rhino/rhino-revit.mdx
+++ b/connectors/rhino/rhino-revit.mdx
@@ -5,14 +5,12 @@ description: 'Using Speckle for Rhino and Revit.'
 
 For better early stage design coordination, use our **Revit Categories** tool to boost your Rhino to Revit or Revit to Rhino workflows.
 
-**Publishing Rhino models for Revit**
-
+Publishing Rhino models for Revit:
 Assign Revit categories to your conceptual Rhino geometry for better coordination in Revit. Your Rhino models will be loaded as **categorized direct shapes** in Revit, allowing you to:
 - create **views with visibility settings** correctly applied to your Rhino geometry
 - create **simple schedules** with category-level object counts including your Rhino geometry. 
 
-**Loading Revit models in Rhino**
-
+Loading Revit models in Rhino:
 Revit models published in Speckle are loaded in Rhino layers based on their Level, Category, and Type. Use the Revit Category tool to easily navigate your loaded model by specific categories.
 
 ### Opening the Revit Categorizer Tool

--- a/connectors/rhino/rhino.mdx
+++ b/connectors/rhino/rhino.mdx
@@ -95,11 +95,11 @@ import LoadFaq from '/snippets/connectors/load-faq.mdx';
       - **With the setting OFF**: Vertex normals, vertex colors, and texture coordinates are not included on meshes, resulting in smaller model sizes.
       - **With the setting ON**: All visualization data is extracted and included.
 
-      **When to enable this:**
+      When to enable this:
       - You want the highest visual fidelity in the Speckle viewer
       - You need full interoperability with rendering tools (e.g., Blender, other Rhino instances)
 
-      **When to keep it disabled:**
+      When to keep it disabled:
       - You want the smallest data sizes possible (e.g., for Power BI or other data-focused workflows)
     </Accordion>
 
@@ -143,7 +143,7 @@ import LoadFaq from '/snippets/connectors/load-faq.mdx';
       Yes. When you load a model that contains views, they are automatically
       created as **named views** in Rhino — no extra steps needed.
 
-      **Notes:**
+      Notes:
       - If a named view with the same name already exists in Rhino, it will be skipped
         and not overwritten.
       - Views published from other connectors (e.g., Revit 3D perspective views) are

--- a/connectors/teklastructures.mdx
+++ b/connectors/teklastructures.mdx
@@ -39,7 +39,7 @@ import NoLoad from '/snippets/connectors/no-load.mdx';
       - Tekla being installed on a non-standard drive
       - Insufficient permissions during installation
       
-      **To resolve this:**
+      To resolve this:
       
       1. Check if the connector files exist in the correct Tekla extensions folder:
          - For Tekla 2025: `C:\TeklaStructures\2025.0\Environments\common\extensions\Speckle3TeklaStructures`

--- a/developers/api/guides/data-validation-results.mdx
+++ b/developers/api/guides/data-validation-results.mdx
@@ -387,8 +387,7 @@ SPECKLE_PROJECT_ID=your_project_id
 %pip install -q specklepy pandas python-dotenv
 ```
 
-**Cell 2 — imports:**
-
+Cell 2 — imports:
 ```python
 import os
 from collections import defaultdict
@@ -401,8 +400,7 @@ from specklepy.api.client import SpeckleClient
 load_dotenv()
 ```
 
-**Cell 3 — authenticate:**
-
+Cell 3 — authenticate:
 ```python
 HOST = os.getenv("SPECKLE_HOST", "https://app.speckle.systems")
 TOKEN = os.getenv("SPECKLE_TOKEN")
@@ -417,8 +415,7 @@ client = SpeckleClient(host=HOST)
 client.authenticate_with_token(TOKEN)
 ```
 
-**Cell 4 — query handler and KPI helpers:**
-
+Cell 4 — query handler and KPI helpers:
 ```python
 DEFAULT_DISPLAY_CONFIG = {
     "passThreshold": 0.9,
@@ -522,8 +519,7 @@ def checks_to_kpi_df(checks: list[dict]) -> pd.DataFrame:
     return pd.DataFrame(rows)
 ```
 
-**Cell 5 — list checks and show the KPI table:**
-
+Cell 5 — list checks and show the KPI table:
 ```python
 result = run_query(LIST_CHECKS_QUERY, {"projectId": PROJECT_ID})
 checks = result.get("projectInsights") or []

--- a/developers/api/guides/file-uploads.mdx
+++ b/developers/api/guides/file-uploads.mdx
@@ -48,8 +48,7 @@ Uploading a file and triggering Speckle's automatic ingestion pipeline is a mult
 5. **Check the ingestion status**
    (GraphQL query for the ingestion progress)
 
-**Important notes:**
-
+Important notes:
 - Large files are never sent through the Speckle Server REST endpoints.
 - The upload URL points to your server's configured blob storage (S3, S3 compatible, or Azure).
 - The ETag returned from Blob storage is required for step 4 (file ingestion).
@@ -61,8 +60,7 @@ We start by notifying the Speckle Server of our intent to upload a file. The ser
 
 **POST** `/graphql`
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation GenerateFileUploadUrl($input: GenerateFileUploadUrlInput!) {
   fileUploadMutations {
@@ -74,8 +72,7 @@ mutation GenerateFileUploadUrl($input: GenerateFileUploadUrlInput!) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "input": {
@@ -85,8 +82,7 @@ mutation GenerateFileUploadUrl($input: GenerateFileUploadUrlInput!) {
 }
 ```
 
-**Response example:**
-
+Response example:
 ```json
 {
   "data": {
@@ -106,26 +102,22 @@ mutation GenerateFileUploadUrl($input: GenerateFileUploadUrlInput!) {
 
 **PUT** `{presignedURL}`
 
-**Headers required:**
-
+Headers required:
 ```
 Content-Type: application/octet-stream   # or appropriate type
 ```
 
-**Body:**
-
+Body:
 ```
 <raw file bytes>
 ```
 
-**Important:**
-
+Important:
 - Blob storage returns an ETag in the headers of the response.
 - The ETag is an unique identifier for the uploaded file content, which Speckle uses to verify the file integrity before ingesting the file.
 - The ETag is required for the final step.
 
-**Example curl:**
-
+Example curl:
 ```bash
 curl -X PUT \
   -H "Content-Type: application/octet-stream" \
@@ -147,8 +139,7 @@ This step requires a target model, where the file data should be ingested to. If
 
 **POST** `/graphql`
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation CreateModel($input: CreateModelInput!) {
   modelMutations {
@@ -159,8 +150,7 @@ mutation CreateModel($input: CreateModelInput!) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "input": {
@@ -170,8 +160,7 @@ mutation CreateModel($input: CreateModelInput!) {
 }
 ```
 
-**Response example:**
-
+Response example:
 ```json
 {
   "data": {
@@ -192,8 +181,7 @@ Once the file is uploaded, tell Speckle to parse, convert, index and create a ne
 
 **POST** `/graphql`
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation StartFileIngestion($input: StartFileImportInput!) {
   fileUploadMutations {
@@ -207,8 +195,7 @@ mutation StartFileIngestion($input: StartFileImportInput!) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "input": {
@@ -222,8 +209,7 @@ mutation StartFileIngestion($input: StartFileImportInput!) {
 
 **Important:** The `fileId` must be the exact value returned from Step 1's `generateUploadUrl` response. Do not use the filename - use the `fileId` from that response.
 
-**Response example:**
-
+Response example:
 ```json
 {
   "data": {
@@ -249,8 +235,7 @@ Once the ingestion has been started, the file ingestion job receives an ingestio
 
 **POST** `/graphql`
 
-**Query:**
-
+Query:
 ```graphql
 query Ingestion($ingestionId: ID!, $projectId: String!) {
   project(id: $projectId) {
@@ -278,8 +263,7 @@ query Ingestion($ingestionId: ID!, $projectId: String!) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "ingestionId": "your-file-ingestion-id",
@@ -287,8 +271,7 @@ query Ingestion($ingestionId: ID!, $projectId: String!) {
 }
 ```
 
-**Response example:**
-
+Response example:
 ```json
 {
   "data": {

--- a/developers/api/guides/project-metadata.mdx
+++ b/developers/api/guides/project-metadata.mdx
@@ -59,8 +59,7 @@ Query permission checks before you build automation:
 
 **POST** `/graphql`
 
-**Query:**
-
+Query:
 ```graphql
 query WorkspaceProjectMetadataPermissions($workspaceId: String!) {
   workspace(id: $workspaceId) {
@@ -89,8 +88,7 @@ query ProjectMetadataPermissions($projectId: String!) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "workspaceId": "your-workspace-id",
@@ -122,8 +120,7 @@ Use this to discover the template before reading or writing project values.
 
 **POST** `/graphql`
 
-**Query:**
-
+Query:
 ```graphql
 query GetWorkspaceProjectMetadataSchema($workspaceId: String!) {
   workspace(id: $workspaceId) {
@@ -137,16 +134,14 @@ query GetWorkspaceProjectMetadataSchema($workspaceId: String!) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "workspaceId": "your-workspace-id"
 }
 ```
 
-**Response example:**
-
+Response example:
 ```json
 {
   "data": {
@@ -190,8 +185,7 @@ Workspace admins define or replace the template for all projects in the workspac
 
 **POST** `/graphql`
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation SetWorkspaceProjectMetadataSchema(
   $input: SetWorkspaceProjectMetadataSchemaInput!
@@ -208,8 +202,7 @@ mutation SetWorkspaceProjectMetadataSchema(
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "input": {
@@ -242,8 +235,7 @@ mutation SetWorkspaceProjectMetadataSchema(
 }
 ```
 
-**Response example:**
-
+Response example:
 ```json
 {
   "data": {
@@ -270,8 +262,7 @@ Invalid schema documents return `PROJECT_METADATA_SCHEMA_DOC_VALIDATION_ERROR` w
 
 **POST** `/graphql`
 
-**Query:**
-
+Query:
 ```graphql
 query GetProjectMetadata($projectId: String!) {
   project(id: $projectId) {
@@ -284,16 +275,14 @@ query GetProjectMetadata($projectId: String!) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "projectId": "your-project-id"
 }
 ```
 
-**Response example:**
-
+Response example:
 ```json
 {
   "data": {
@@ -320,8 +309,7 @@ query GetProjectMetadata($projectId: String!) {
 
 **POST** `/graphql`
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation UpdateProjectMetadata($input: UpdateProjectMetadataInput!) {
   projectMutations {
@@ -336,8 +324,7 @@ mutation UpdateProjectMetadata($input: UpdateProjectMetadataInput!) {
 }
 ```
 
-**Variables example (partial update):**
-
+Variables example (partial update):
 ```json
 {
   "input": {
@@ -350,8 +337,7 @@ mutation UpdateProjectMetadata($input: UpdateProjectMetadataInput!) {
 }
 ```
 
-**Variables example (clear one key):**
-
+Variables example (clear one key):
 ```json
 {
   "input": {
@@ -363,8 +349,7 @@ mutation UpdateProjectMetadata($input: UpdateProjectMetadataInput!) {
 }
 ```
 
-**Response example:**
-
+Response example:
 ```json
 {
   "data": {
@@ -384,8 +369,7 @@ mutation UpdateProjectMetadata($input: UpdateProjectMetadataInput!) {
 }
 ```
 
-**Common errors:**
-
+Common errors:
 - `PROJECT_METADATA_SCHEMA_NOT_CONFIGURED` — workspace has no template yet
 - `PROJECT_METADATA_VALUES_VALIDATION_ERROR` — value fails type, enum, pattern, or URI format checks
 
@@ -395,8 +379,7 @@ Workspace admins can remove the template and all stored values. This is irrevers
 
 **POST** `/graphql`
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation DeleteWorkspaceProjectMetadataSchema($workspaceId: ID!) {
   workspaceMutations {
@@ -410,8 +393,7 @@ mutation DeleteWorkspaceProjectMetadataSchema($workspaceId: ID!) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "workspaceId": "your-workspace-id"

--- a/developers/api/guides/slack-notifications.mdx
+++ b/developers/api/guides/slack-notifications.mdx
@@ -278,22 +278,22 @@ Your webhook endpoint doesn't need to be a full server - it just needs to be a p
 
 ### Serverless Functions (Recommended)
 
-**AWS Lambda:**
+AWS Lambda:
 - Create a Lambda function with an API Gateway trigger
 - Deploy your code and get a public URL
 - Pay only for requests (very cost-effective)
 
-**Google Cloud Functions:**
+Google Cloud Functions:
 - Deploy as an HTTP function
 - Automatically gets a public HTTPS URL
 - Scales automatically
 
-**Azure Functions:**
+Azure Functions:
 - Create an HTTP-triggered function
 - Get a public endpoint URL
 - Serverless scaling
 
-**Vercel / Netlify Functions:**
+Vercel / Netlify Functions:
 - Deploy as a serverless function
 - Automatic HTTPS and scaling
 - Great for simple integrations
@@ -475,8 +475,7 @@ if (event.event_name === 'branch_update') {
 ## Security Considerations
 
 <Warning>
-**Important Security Notes:**
-
+Important Security Notes:
 1. **Verify Webhook Signatures**: Always verify that webhooks are actually coming from Speckle. See [Webhook Security](../webhooks/security) for signature verification code.
 
 2. **Protect Your Slack Webhook URL**: Keep your Slack webhook URL in environment variables, never commit it to version control.

--- a/developers/api/guides/updating-syncs.mdx
+++ b/developers/api/guides/updating-syncs.mdx
@@ -69,8 +69,7 @@ Use this to discover sync IDs before updating.
 
 **POST** `/graphql`
 
-**Query:**
-
+Query:
 ```graphql
 query ProjectSyncs($projectId: String!, $limit: Int, $cursor: String) {
   project(id: $projectId) {
@@ -91,8 +90,7 @@ query ProjectSyncs($projectId: String!, $limit: Int, $cursor: String) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "projectId": "0d1f93ec13",
@@ -105,8 +103,7 @@ query ProjectSyncs($projectId: String!, $limit: Int, $cursor: String) {
 
 **POST** `/graphql`
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation UpdateSync($input: UpdateSyncInput!) {
   syncMutations {
@@ -120,8 +117,7 @@ mutation UpdateSync($input: UpdateSyncInput!) {
 }
 ```
 
-**Variables example:**
-
+Variables example:
 ```json
 {
   "input": {
@@ -136,8 +132,7 @@ mutation UpdateSync($input: UpdateSyncInput!) {
 }
 ```
 
-**Input fields:**
-
+Input fields:
 `UpdateSyncInput` supports:
 
 - `id` (`ID!`): Sync identifier
@@ -172,8 +167,7 @@ Typical context payload shape for ACC and ProjectWise syncs:
   fields. Common keys in ACC and ProjectWise flows include `referencePoint` and `viewName`.
 </Note>
 
-**Response example:**
-
+Response example:
 ```json
 {
   "data": {

--- a/developers/api/rest.mdx
+++ b/developers/api/rest.mdx
@@ -8,7 +8,7 @@ This REST API reference is provided for developers who need direct access to RES
 ## Overview
 
 <Warning>
-  **We strongly recommend using our [SDKs](../sdks) first, and the [GraphQL API](./graphql) second, before considering the REST API.**
+  We strongly recommend using our [SDKs](../sdks) first, and the [GraphQL API](./graphql) second, before considering the REST API.:
   
   While the REST API is fully stable, using it directly presents many opportunities for user error that can lead to undesirable outcomes such as zombie objects. The SDKs provide a safer, more intuitive interface with proper error handling and safeguards, while the GraphQL API offers better flexibility and type safety than raw REST endpoints.
 </Warning>

--- a/developers/api/webhooks/events.mdx
+++ b/developers/api/webhooks/events.mdx
@@ -20,7 +20,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="project_update">
     **Payload Event Name:** `stream_update`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "streamId": "project-id",
@@ -36,7 +36,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="project_delete">
     **Payload Event Name:** `stream_delete`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "streamId": "project-id"
@@ -52,7 +52,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="model_create">
     **Payload Event Name:** `branch_create`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "branchId": "branch-id",
@@ -66,7 +66,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="model_update">
     **Payload Event Name:** `branch_update`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "branchId": "branch-id",
@@ -83,7 +83,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="model_delete">
     **Payload Event Name:** `branch_delete`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "branchId": "branch-id",
@@ -100,7 +100,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="version_create">
     **Payload Event Name:** `commit_create`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "commitId": "commit-id",
@@ -116,7 +116,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="version_update">
     **Payload Event Name:** `commit_update`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "commitId": "commit-id",
@@ -138,7 +138,7 @@ You can configure webhooks to trigger on the following events. The event names s
     imported into a different application).
     </Note>
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "commitId": "commit-id",
@@ -154,7 +154,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="version_delete">
     **Payload Event Name:** `commit_delete`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "commitId": "commit-id",
@@ -171,7 +171,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="comment_created">
     **Payload Event Name:** `comment_created`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "commentId": "comment-id",
@@ -187,7 +187,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="comment_archived">
     **Payload Event Name:** `comment_archived`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "commentId": "comment-id",
@@ -201,7 +201,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="comment_replied">
     **Payload Event Name:** `comment_replied`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "commentId": "comment-id",
@@ -222,7 +222,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="project_permissions_add">
     **Payload Event Name:** `stream_permissions_add`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "streamId": "project-id",
@@ -236,7 +236,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="project_permissions_remove">
     **Payload Event Name:** `stream_permissions_remove`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "streamId": "project-id",
@@ -254,7 +254,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="issue_created">
     **Payload Event Name:** `issue_created`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "issue": {
@@ -273,7 +273,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="issue_updated">
     **Payload Event Name:** `issue_updated`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "issue": {
@@ -291,7 +291,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="issue_reply_created">
     **Payload Event Name:** `issue_reply_created`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "issue": {
@@ -310,7 +310,7 @@ You can configure webhooks to trigger on the following events. The event names s
   <Tab title="issue_deleted">
     **Payload Event Name:** `issue_deleted`
 
-    **Payload `event.data`:**
+    Payload `event.data`:
     ```json
     {
       "issue": {

--- a/developers/api/webhooks/security.mdx
+++ b/developers/api/webhooks/security.mdx
@@ -63,14 +63,12 @@ if (!isValid) {
 <Warning>
 **Critical**: Any time you make a commit (create a version) in response to a triggered webhook event, you are at risk of creating an infinite loop on both your handling code and your Speckle server. Use caution and ensure that you safely exit your handling code when no change is needed.
 
-**If you trigger an infinite loop:**
-
+If you trigger an infinite loop:
 - Make your endpoint inaccessible immediately
 - Deploy new code that prevents the loop
 - Delete the webhook on the server/project
 
-**Best practices to prevent loops:**
-
+Best practices to prevent loops:
 - Check if changes are actually needed before creating new versions
 - Use conditional logic to exit early when no action is required
 - Implement idempotency checks to avoid reprocessing the same event

--- a/developers/authentication/introduction.mdx
+++ b/developers/authentication/introduction.mdx
@@ -16,14 +16,14 @@ Speckle supports multiple authentication mechanisms for different use cases. Cho
 
 <CardGroup cols={2}>
   <Card title="Use Personal Access Tokens" icon="key">
-    **When:**
+    When:
     - Single-user tools or scripts
     - Server-side applications
     - Automation and CI/CD
     - Personal development projects
   </Card>
   <Card title="Use OAuth2 with PKCE" icon="shield">
-    **When:**
+    When:
     - Multi-user web applications
     - Public-facing apps
     - Third-party integrations
@@ -38,7 +38,7 @@ Speckle supports multiple authentication mechanisms for different use cases. Cho
 Treat all tokens as sensitive information. Proper token management is critical for security.
 
 <Check>
-**Do:**
+Do:
 - Store tokens in environment variables
 - Use `.gitignore` to exclude `.env` files
 - Rotate tokens periodically
@@ -49,7 +49,7 @@ Treat all tokens as sensitive information. Proper token management is critical f
 </Check>
 
 <Warning>
-**Don't:**
+Don't:
 - Commit tokens to version control
 - Share tokens between team members
 - Use PATs in client-side code (use OAuth instead)

--- a/developers/authentication/oauth2.mdx
+++ b/developers/authentication/oauth2.mdx
@@ -31,8 +31,7 @@ Before using OAuth2, you need to register your application:
 
 Once registered, your application can request specific scopes that define the level of access to user data. Users can review and revoke these permissions at any time through their account settings.
 
-**Common Scopes:**
-
+Common Scopes:
 | Scope           | Description                | Use Case                 |
 | --------------- | -------------------------- | ------------------------ |
 | `streams:read`  | Read project data          | View-only applications   |
@@ -75,12 +74,10 @@ The whole flow consists of the following steps:
 4. **Receive Authorization Code**: Speckle redirects back with an authorization code
 5. **Exchange for Token**: Your app exchanges the code + verifier for an access token
 
-**Using the speckle-auth package (Recommended):**
-
+Using the speckle-auth package (Recommended):
 The community-maintained [speckle-auth](https://www.npmjs.com/package/speckle-auth) package simplifies OAuth2 implementation by handling PKCE generation, state management, and token exchange automatically.
 
-**Manual Implementation:**
-
+Manual Implementation:
 The following is a complete step-by-step browser implementation of Speckle's OAuth2 PKCE flow. It uses the dedicated `/oauth/token` endpoint, which enforces full RFC 7636 PKCE: the server stores the `codeChallenge` (`BASE64URL(SHA256(codeVerifier))`) during authorization and verifies the raw `codeVerifier` on token exchange.
 
 <Steps>

--- a/developers/automate/function-artefacts.mdx
+++ b/developers/automate/function-artefacts.mdx
@@ -20,8 +20,7 @@ Speckle Automate provides multiple methods for generating and storing function r
 
 This method allows automation functions to produce structured Speckle models, enabling users to store and interact with augmented, synthesized, or entirely new geometry and data.
 
-**When to Use It**
-
+When to Use It:
 This method aligns with workflows where data should remain interactive, allowing downstream applications to consume and manipulate the generated results.
 
 - **Augmenting an existing model**: Enhancing a source model with derived data, such as clash results, enriched metadata, or structural analysis outcomes.
@@ -32,8 +31,7 @@ This method aligns with workflows where data should remain interactive, allowing
 
 File artifacts serve as an alternative when the function output is best represented as a document, dataset, or visualization rather than an interactive Speckle model.
 
-**When to Use It**
-
+When to Use It:
 Unlike model versions, file artifacts are adjacent to the Speckle ecosystem, meaning they don't provide interactive elements within Speckle itself but can be downloaded and used externally.
 
 - **Exporting non-native formats**: Storing alternative representations of model data, such as .obj, .gltf, or .dotbim files for use in third-party applications.

--- a/developers/automate/publishing-without-github.mdx
+++ b/developers/automate/publishing-without-github.mdx
@@ -20,8 +20,7 @@ If you're running a dedicated enterprise deployment and can't use the GitHub App
 
 Send the following GraphQL mutation to your **Speckle server** (e.g. `https://app.speckle.systems`) to create a new function entry. This does not publish any runnable code yet — it just registers the function and returns credentials you'll use in subsequent steps.
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation ($input: CreateAutomateFunctionWithoutVersionInput!) {
   automateMutations {
@@ -33,8 +32,7 @@ mutation ($input: CreateAutomateFunctionWithoutVersionInput!) {
 }
 ```
 
-**Variables:**
-
+Variables:
 ```json
 {
   "input": {
@@ -44,8 +42,7 @@ mutation ($input: CreateAutomateFunctionWithoutVersionInput!) {
 }
 ```
 
-**Response:**
-
+Response:
 ```json
 {
   "data": {
@@ -148,8 +145,7 @@ A successful response returns the new version ID:
 
 At this point the function is registered and has a published version, but it isn't visible to any workspace yet. Run the following mutation against your Speckle server to associate the function with one or more workspaces:
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation ($input: UpdateAutomateFunctionInput!) {
   automateMutations {
@@ -160,8 +156,7 @@ mutation ($input: UpdateAutomateFunctionInput!) {
 }
 ```
 
-**Variables:**
-
+Variables:
 ```json
 {
   "input": {
@@ -184,8 +179,7 @@ For a deeper dive into building Automate functions, check out the [Automate docu
 If the function token needs to be regenerated for some reason the mutation below with create a new token.
 Keep in mind, only the original function author user is authorized to run this mutation.
 
-**Mutation:**
-
+Mutation:
 ```graphql
 mutation($functionId: String!) {
   automateMutations {
@@ -194,8 +188,7 @@ mutation($functionId: String!) {
 }
 ```
 
-**Variables:**
-
+Variables:
 ```json
 {
   "functionId": "<your-function-id>"

--- a/developers/connectivity/cloud-automation.mdx
+++ b/developers/connectivity/cloud-automation.mdx
@@ -6,8 +6,7 @@ description: Connect Speckle to external systems with server-side jobs, ETL, orc
 
 **When to use:** Server-side jobs move data **between Speckle and other systems** (ETL, orchestration, CI), or react to new **versions** to update external tools.
 
-**Typical stack:**
-
+Typical stack:
 - [specklepy](/developers/sdks/python/introduction) or GraphQL directly
 - [Webhooks](/developers/api/webhooks) for version events
 

--- a/developers/connectivity/desktop-host.mdx
+++ b/developers/connectivity/desktop-host.mdx
@@ -10,8 +10,7 @@ Decide [publish, load, and integration depth](/developers/connectivity/integrati
 
 **When to use:** Code runs inside a CAD/BIM/structural desktop application (Revit, Rhino, Tekla Structures, ETABS, or a custom host). Users send or receive from that application’s UI.
 
-**Typical stack:**
-
+Typical stack:
 - C# / .NET in the host process
 - [speckle-sharp-sdk](https://github.com/specklesystems/speckle-sharp-sdk) — server and object APIs
 - [speckle-sharp-connectors](https://github.com/specklesystems/speckle-sharp-connectors) — DUI, converters, send/receive pipelines
@@ -24,8 +23,7 @@ Decide [publish, load, and integration depth](/developers/connectivity/integrati
 
 **When to use:** A standalone tray app, agent, or background service talks to Speckle and optionally calls host APIs (COM, export, file watch)—without living inside the host UI.
 
-**Typical stack:**
-
+Typical stack:
 - [speckle-sharp-sdk](https://github.com/specklesystems/speckle-sharp-sdk) or [specklepy](/developers/sdks/python/introduction)
 - [GraphQL API](/developers/api/graphql) for projects, models, and versions
 

--- a/developers/connectivity/integration-depth.mdx
+++ b/developers/connectivity/integration-depth.mdx
@@ -41,7 +41,7 @@ Depth describes how much you invest after the host can publish reliably. Each st
   <Step title="Publish">
     **Goal:** Reliable extraction from the host into Speckle.
 
-    **Includes:**
+    Includes:
 
     - Geometry (meshes, curves, points, display values)
     - Metadata (parameters, identifiers, discipline-specific properties)
@@ -51,7 +51,7 @@ Depth describes how much you invest after the host can publish reliably. Each st
 
     **When to stop:** Coordination, visualization, ETL, reporting, or cloud processing only need published data. **Most connectors can ship at publish depth.**
 
-    **Speckle connectors (examples):**
+    Speckle connectors (examples):
 
     - [ETABS](/connectors/etabs) — publish-only; structural model and analysis-oriented publish
     - [Tekla Structures](/connectors/teklastructures) — publish-only
@@ -63,7 +63,7 @@ Depth describes how much you invest after the host can publish reliably. Each st
   <Step title="Load: reference geometry">
     **Goal:** Bring Speckle geometry into the host as **reference** content—not editable native model semantics.
 
-    **Typical behaviour:**
+    Typical behaviour:
 
     - Place meshes or simplified geometry for coordination
     - Optional transforms, layers, or visibility by source model
@@ -71,7 +71,7 @@ Depth describes how much you invest after the host can publish reliably. Each st
 
     **Requires:** Publish and load in the product sense, but still **not** round-trip.
 
-    **Speckle connectors (examples):**
+    Speckle connectors (examples):
 
     - [Revit](/connectors/revit/revit) — default load as Direct Shapes (generic models) for coordination geometry
     - [Rhino](/connectors/rhino/rhino), [Blender](/connectors/blender), [SketchUp](/connectors/sketchup), [Archicad](/connectors/archicad), [Civil 3D](/connectors/civil3d), [AutoCAD](/connectors/autocad) — load workflows documented per connector
@@ -81,7 +81,7 @@ Depth describes how much you invest after the host can publish reliably. Each st
   <Step title="Load: interop lite">
     **Goal:** Smarter load without full native object reconstruction.
 
-    **Typical behaviour:**
+    Typical behaviour:
 
     - **Category mapping** — map Speckle types or layers to host categories, families, or styles
     - **Metadata transfer** — attach parameters or properties to reference elements
@@ -89,7 +89,7 @@ Depth describes how much you invest after the host can publish reliably. Each st
 
     **Tradeoff:** More useful than raw reference geometry; less cost than native translation.
 
-    **Speckle connectors (examples):**
+    Speckle connectors (examples):
 
     - [Revit](/connectors/revit/revit) — materials and parameters on loaded objects; category and type behaviour described in connector FAQ
     - [Grasshopper](/connectors/grasshopper/grasshopper) — receive workflows with property and parameter-driven filtering
@@ -99,7 +99,7 @@ Depth describes how much you invest after the host can publish reliably. Each st
   <Step title="Load: pragmatic interop">
     **Goal:** Recreate selected native host objects from Speckle data where it is worth the maintenance.
 
-    **Typical behaviour:**
+    Typical behaviour:
 
     - Native walls, members, grids, or discipline-specific types where converters exist
     - Explicit scope: which types translate, which stay as reference geometry
@@ -107,7 +107,7 @@ Depth describes how much you invest after the host can publish reliably. Each st
 
     **Tradeoff:** Highest implementation and test burden. Still **not** round-trip: publish and load remain separate operations with different conversion logic.
 
-    **Speckle connectors (examples):**
+    Speckle connectors (examples):
 
     - [Revit](/connectors/revit/revit) — native element load where supported by the connector
     - [Blocks as Families](/connectors/revit/blocks-to-families) — load block instances as Revit families (optional load setting)

--- a/developers/connectivity/middleware.mdx
+++ b/developers/connectivity/middleware.mdx
@@ -6,8 +6,7 @@ description: Connect Speckle to enterprise systems as a middleware or orchestrat
 
 **When to use:** Your integration sits between Speckle and enterprise systems (PLM, data lakes, scheduling, proprietary APIs) without owning a host-application UI.
 
-**Typical stack:**
-
+Typical stack:
 - [GraphQL API](/developers/api/graphql) and [REST](/developers/api/rest) where documented
 - [specklepy](/developers/sdks/python/introduction) or [@speckle/objectsender](/developers/packages/objectsender) / [@speckle/objectloader2](/developers/packages/objectloader2) depending on runtime
 - Idempotent, version-aware sync patterns

--- a/developers/data-schema/concepts.mdx
+++ b/developers/data-schema/concepts.mdx
@@ -45,7 +45,7 @@ These are the atomic building blocks that combine to form objects.
 
 In JSON, detached properties appear with an `@` prefix (e.g., `"@atomic_object_collection": "hash123..."`). The actual object is stored in the transport layer and automatically resolved when the data is received.
 
-**Key points:**
+Key points:
 - **Automatic**: Detachment happens automatically during serialization for large properties
 - **Transparent**: References are automatically resolved during `receive()` operations
 - **Efficient**: Prevents large objects from bloating JSON payloads

--- a/developers/data-schema/geometry-schema.mdx
+++ b/developers/data-schema/geometry-schema.mdx
@@ -7,8 +7,7 @@ This page explains how geometry is structured and organized in Speckle's data mo
 
 ## Geometry Storage Rule
 
-**All visual geometry for a DataObject must be in `displayValue`.**
-
+All visual geometry for a DataObject must be in `displayValue`.:
 ```mermaid
 classDiagram
     class DataObject {
@@ -94,7 +93,7 @@ Conceptually, a mesh is a surface composed of polygons where:
 - The mesh represents a surface through connected polygons (triangles are most common, but quads and ngons are supported)
 - **Hard-edged faces**: Speckle does not implicitly normalize meshes—they are sent as hard-edged faces, preserving the exact geometry from the source application
 
-**Optional fields:**
+Optional fields:
 - **colors**: Colors are stored per vertex (RGB values). Faces take the average of their vertex colors, enabling quasi-texture mapping or visualization of analytical results (e.g., stress values, temperature gradients).
 - **normals**: Vertex normals are supported but not heavily used in connectors due to lack of host application support.
 - **textureCoordinates**: Not yet utilized in the current implementation.

--- a/developers/data-schema/overview.mdx
+++ b/developers/data-schema/overview.mdx
@@ -108,8 +108,7 @@ The Speckle data schema is structured as a **directed tree**. This is the core r
 - **Flat object graph (best practice)**: As a general rule, objects don't nest within other objects—they're organized in collections and referenced via proxies. Some DataObjects (e.g., Revit curtain walls) may use an `elements` property when required by the source application.
 - **Proxies add cross-cutting relationships**: While the collection hierarchy is a tree, proxies create additional relationships (materials, levels, groups) that reference objects by `applicationId`
 
-**Key relationship rules:**
-
+Key relationship rules:
 1. Collections contain objects and other collections (via `elements` property)
 2. DataObjects contain geometry in `displayValue` (and may contain child DataObjects via `elements` in some cases)
 3. Proxies reference objects by `applicationId` (stored at root level)

--- a/developers/data-schema/proxy-schema.mdx
+++ b/developers/data-schema/proxy-schema.mdx
@@ -284,7 +284,7 @@ In addition to proxies, Speckle supports direct reference objects that point to 
 }
 ```
 
-**Fields:**
+Fields:
 - **`referencedId`** (required) - The object `id` (hash) of the referenced object
 - **`closure`** (optional) - Dictionary mapping closure information
 
@@ -304,7 +304,7 @@ Unlike proxies which reference by `applicationId` and are stored at root level, 
 }
 ```
 
-**Fields:**
+Fields:
 - **`definitionId`** (required) - The `applicationId` of the Definition proxy that contains the geometry
 - **`transform`** (required) - 4x4 transformation matrix for the instance placement
 - **`units`** (required) - Units of the host application file

--- a/developers/introduction.mdx
+++ b/developers/introduction.mdx
@@ -19,14 +19,12 @@ Welcome to Speckle's Developer Documentation! Here you'll find everything you ne
 
 ## What Can You Build?
 
-**On Speckle (platform):**
-
+On Speckle (platform):
 - **Custom applications** — Web apps, visualizations, and tools using the viewer and data APIs
 - **Automate workflows** — Serverless functions that process model data when new versions arrive
 - **Self-hosted server** — Deploy and customize your own Speckle server instance
 
-**With Speckle (connectivity):**
-
+With Speckle (connectivity):
 - **Connectors and host add-ins** — Send and receive between Speckle and CAD/BIM/structural applications
 - **Pipelines and middleware** — Sync Speckle with databases, PLM, scheduling, or proprietary APIs
 

--- a/developers/packages/objectloader2.mdx
+++ b/developers/packages/objectloader2.mdx
@@ -38,9 +38,7 @@ const object = await loader.getAndConstructObject();
 
 For complete documentation, examples, and API reference, visit the package on npm:
 
-**[View on npm →](https://www.npmjs.com/package/@speckle/objectloader2)**
-
-
+[View on npm →](https://www.npmjs.com/package/@speckle/objectloader2):
 <Note>
 This documentation is a stub. Full documentation coming soon. For now, refer to the npm package page for detailed usage examples and API documentation.
 </Note>

--- a/developers/packages/objectsender.mdx
+++ b/developers/packages/objectsender.mdx
@@ -38,9 +38,7 @@ const objectId = await sender.sendObject(myObject);
 
 For complete documentation, examples, and API reference, visit the package on npm:
 
-**[View on npm →](https://www.npmjs.com/package/@speckle/objectsender)**
-
-
+[View on npm →](https://www.npmjs.com/package/@speckle/objectsender):
 <Note>
 This documentation is a stub. Full documentation coming soon. For now, refer to the npm package page for detailed usage examples and API documentation.
 </Note>

--- a/developers/packages/viewer.mdx
+++ b/developers/packages/viewer.mdx
@@ -40,9 +40,7 @@ For complete documentation, see the [Viewer API documentation](/developers/viewe
 
 For package-specific details, examples, and API reference, visit the package on npm:
 
-**[View on npm →](https://www.npmjs.com/package/@speckle/viewer)**
-
-
+[View on npm →](https://www.npmjs.com/package/@speckle/viewer):
 <Note>
 This package documentation is a stub. For comprehensive Viewer documentation, see the [Viewer API section](/developers/viewer/introduction). For package-specific details, refer to the npm package page.
 </Note>

--- a/developers/sdks/dotnet/getting-started/authentication.mdx
+++ b/developers/sdks/dotnet/getting-started/authentication.mdx
@@ -173,14 +173,14 @@ if (!string.IsNullOrEmpty(account.token))
 ## Security Best Practices
 
 <Check>
-**Do:**
+Do:
 - Store tokens in environment variables or a secret manager
 - Use scoped tokens with the minimum permissions your application needs
 - Revoke tokens when they're no longer needed
 </Check>
 
 <Warning>
-**Don't:**
+Don't:
 - Commit tokens to version control
 - Share tokens between team members or applications
 - Use personal access tokens in client-side or distributed desktop code — prefer OAuth for multi-user applications

--- a/developers/sdks/dotnet/getting-started/quickstart.mdx
+++ b/developers/sdks/dotnet/getting-started/quickstart.mdx
@@ -201,8 +201,7 @@ Console.WriteLine($"Points received: {((List<object>)receivedData["points"]!).Co
 ```
 
 <Info>
-**Why two steps?**
-
+Why two steps?:
 Versions store metadata (author, timestamp, message) separately from the actual object data. This keeps version history fast and lightweight. You only download the full object graph when you explicitly call `Receive`.
 </Info>
 

--- a/developers/sdks/python/api-reference/client.mdx
+++ b/developers/sdks/python/api-reference/client.mdx
@@ -37,8 +37,7 @@ SpeckleClient(
 
 Creates a new Speckle client instance.
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="host" type="str" default='"https://app.speckle.systems"'>
   The Speckle server URL including protocol
 </ResponseField>
@@ -51,8 +50,7 @@ Creates a new Speckle client instance.
   Whether to verify SSL certificates
 </ResponseField>
 
-**Examples:**
-
+Examples:
 <Tabs>
   <Tab title="Hosted Server">
     ```python
@@ -100,14 +98,12 @@ client.authenticate_with_token(token: str) -> None
 
 Authenticate using a personal access token.
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="token" type="str" required>
   Personal access token from your Speckle profile
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 from specklepy.api.client import SpeckleClient
 
@@ -128,14 +124,12 @@ client.authenticate_with_account(account: Account) -> None
 
 Authenticate using an Account object from local Speckle Manager/Connector.
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="account" type="Account" required>
   Account object from `get_default_account()` or `get_local_accounts()`
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 from specklepy.api.client import SpeckleClient
 from specklepy.api.credentials import get_default_account
@@ -160,8 +154,7 @@ client.account: Account
 
 The currently authenticated account. Contains user information after authentication.
 
-**Example:**
-
+Example:
 ```python
 client.authenticate_with_token(token)
 
@@ -175,8 +168,7 @@ print(f"User ID: {client.account.userInfo.id}")
 The client provides access to various resource APIs through these properties. Each resource has its own detailed documentation page.
 
 <Note>
-**Listing Projects: Workspace vs Non-Workspace Servers**
-
+Listing Projects: Workspace vs Non-Workspace Servers:
 The method for listing projects differs depending on your server deployment:
 
 - **Workspace-enabled servers** (e.g., app.speckle.systems): Use `client.workspace.get_projects(workspace_id)` to list projects within a workspace, or `client.active_user.get_projects(filter=UserProjectsFilter(personalOnly=True))` for personal projects.
@@ -209,8 +201,7 @@ client.project: ProjectResource
 
 Access project operations (create, get, update, delete, list).
 
-**Example:**
-
+Example:
 ```python
 from specklepy.core.api.inputs.project_inputs import ProjectCreateInput
 
@@ -232,8 +223,7 @@ client.model: ModelResource
 
 Access model operations (create, get, update, delete, list).
 
-**Example:**
-
+Example:
 ```python
 from specklepy.core.api.inputs.model_inputs import CreateModelInput
 
@@ -253,8 +243,7 @@ client.version: VersionResource
 
 Access version operations (create, get, list, update, delete).
 
-**Example:**
-
+Example:
 ```python
 from specklepy.core.api.inputs.version_inputs import CreateVersionInput
 
@@ -276,8 +265,7 @@ client.active_user: ActiveUserResource
 
 Operations on the currently authenticated user (get profile, update, get projects, etc.).
 
-**Example:**
-
+Example:
 ```python
 user = client.active_user.get()
 print(f"Name: {user.name}")
@@ -294,8 +282,7 @@ client.other_user: OtherUserResource
 
 Operations for looking up other users (get by ID, search).
 
-**Example:**
-
+Example:
 ```python
 user = client.other_user.get(user_id="other_user_id")
 results = client.other_user.search(query="john")
@@ -311,8 +298,7 @@ client.server: ServerResource
 
 Server information and metadata.
 
-**Example:**
-
+Example:
 ```python
 version = client.server.version()
 info = client.server.get()
@@ -329,8 +315,7 @@ client.workspace: WorkspaceResource
 ```
 
 <Note>
-**Workspace Resource Availability**
-
+Workspace Resource Availability:
 The `workspace` resource is available on the hosted Speckle server at **app.speckle.systems** and other workspace-enabled deployments.
 
 **Self-hosted/open-source server deployments do not include workspace features** and this resource will not be available. Attempting to use workspace methods on non-workspace servers will raise an error.
@@ -341,8 +326,7 @@ Check your server capabilities before using workspace operations, or wrap calls 
 
 Workspace operations (get workspace details, members, projects, settings).
 
-**Example:**
-
+Example:
 ```python
 try:
     workspace = client.workspace.get("workspace_id")
@@ -365,20 +349,17 @@ client.execute_query(query: str) -> Dict
 
 Execute a raw GraphQL query against the Speckle server.
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="query" type="str" required>
   GraphQL query string (use `gql()` for proper formatting)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="response" type="Dict">
   Raw GraphQL response
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 from gql import gql
 from specklepy.api.client import SpeckleClient
@@ -416,8 +397,7 @@ Use `execute_query()` when you need to:
 - Use new API features before SDK support is added
 - Optimize queries by requesting only needed fields
 
-**Example - Custom Fields:**
-
+Example - Custom Fields:
 ```python
 # Query custom or new fields not in SDK
 query = gql("""
@@ -437,8 +417,7 @@ query = gql("""
 result = client.execute_query(query)
 ```
 
-**Example - Mutations:**
-
+Example - Mutations:
 ```python
 # Custom mutation not yet in SDK
 mutation = gql("""
@@ -457,8 +436,7 @@ result = client.execute_query(mutation)
 ```
 
 <Note>
-**GraphQL Schema Documentation**
-
+GraphQL Schema Documentation:
 To explore available queries, mutations, and fields, visit your Speckle server's GraphQL playground:
 
 - Hosted server: `https://app.speckle.systems/graphql`

--- a/developers/sdks/python/api-reference/exceptions.mdx
+++ b/developers/sdks/python/api-reference/exceptions.mdx
@@ -39,13 +39,13 @@ class GraphQLException(SpeckleException):
     data: Optional[Any]
 ```
 
-**Common causes:**
+Common causes:
 - Invalid object IDs
 - Resource not found
 - Permission denied
 - Server errors
 
-**Example:**
+Example:
 ```python
 from specklepy.logging.exceptions import GraphQLException
 
@@ -67,7 +67,7 @@ class SerializationException(SpeckleException):
     exception: Optional[Exception]
 ```
 
-**Common causes:**
+Common causes:
 - Non-Speckle objects without conversion
 - Circular references
 - Unsupported data types
@@ -82,7 +82,7 @@ class UnsupportedException(SpeckleException):
     message: str
 ```
 
-**Common causes:**
+Common causes:
 - Features unavailable on older server versions
 - Unsupported object types
 - Platform-specific features
@@ -108,7 +108,7 @@ class WorkspacePermissionException(SpeckleException):
     message: str
 ```
 
-**Common causes:**
+Common causes:
 - Insufficient workspace permissions
 - Workspace features not available on server
 - Not a member of the workspace

--- a/developers/sdks/python/api-reference/operations.mdx
+++ b/developers/sdks/python/api-reference/operations.mdx
@@ -36,8 +36,7 @@ operations.send(
 ) -> str
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="base" type="Base" required>
   The object to send
 </ResponseField>
@@ -50,14 +49,12 @@ operations.send(
   Whether to also save to the local SQLite cache
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="object_id" type="str">
   The object ID (hash) of the sent object
 </ResponseField>
 
-**Examples:**
-
+Examples:
 <Tabs>
   <Tab title="Send to Server">
     ```python
@@ -163,8 +160,7 @@ operations.receive(
 ) -> Base
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="obj_id" type="str" required>
   The ID of the object to receive
 </ResponseField>
@@ -177,14 +173,12 @@ operations.receive(
   The local cache to check first. Defaults to SQLiteTransport
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="object" type="Base">
   The received object, fully recomposed with all children
 </ResponseField>
 
-**Examples:**
-
+Examples:
 <Tabs>
   <Tab title="Receive from Server">
     ```python
@@ -278,8 +272,7 @@ operations.serialize(
 ) -> str
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="base" type="Base" required>
   The object to serialize
 </ResponseField>
@@ -287,14 +280,12 @@ operations.serialize(
   Transports to write detached objects to. If `None`, objects are serialized inline without detachment
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="json_string" type="str">
   JSON string representation of the object
 </ResponseField>
 
-**Examples:**
-
+Examples:
 <Tabs>
   <Tab title="Simple Serialization">
     ```python
@@ -367,8 +358,7 @@ operations.deserialize(
 ) -> Base
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="obj_string" type="str" required>
   JSON string to deserialize
 </ResponseField>
@@ -376,14 +366,12 @@ operations.deserialize(
   Transport to read detached/referenced objects from. Defaults to SQLiteTransport
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="object" type="Base">
   The deserialized object
 </ResponseField>
 
-**Examples:**
-
+Examples:
 <Tabs>
   <Tab title="Simple Deserialization">
     ```python

--- a/developers/sdks/python/api-reference/resources/active-user.mdx
+++ b/developers/sdks/python/api-reference/resources/active-user.mdx
@@ -32,14 +32,12 @@ client.active_user.get() -> Optional[User]
 
 **Parameters:** None
 
-**Returns:**
-
+Returns:
 <ResponseField name="user" type="User | None">
   Your user profile, or `None` if not authenticated. See [User](#user)
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 user = client.active_user.get()
 
@@ -63,20 +61,17 @@ Update your user profile.
 client.active_user.update(input: UserUpdateInput) -> User
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="UserUpdateInput" required>
   Profile update parameters. See [UserUpdateInput](#userupdateinput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="user" type="User">
   The updated user profile. See [User](#user)
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.user_inputs import UserUpdateInput
 
@@ -89,8 +84,7 @@ updated_user = client.active_user.update(UserUpdateInput(
 print(f"Updated profile: {updated_user.name}")
 ```
 
-**UserUpdateInput Fields:**
-
+UserUpdateInput Fields:
 - `name` (str, optional) - New display name
 - `bio` (str, optional) - New biography
 - `company` (str, optional) - New company name
@@ -106,8 +100,7 @@ print(f"Updated profile: {updated_user.name}")
 Get all projects you have access to.
 
 <Note>
-**When to use this method:**
-
+When to use this method:
 - **Non-workspace servers** (self-hosted/open-source): Use this method to list all projects you have access to.
 - **Workspace-enabled servers** (e.g., app.speckle.systems): Use this method with filters to list personal projects, or use `client.workspace.get_projects(workspace_id)` to list projects within a specific workspace.
 
@@ -126,8 +119,7 @@ client.active_user.get_projects(
 ) -> ResourceCollection[Project]
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="limit" type="int" default="25">
   Maximum number of projects to return
 </ResponseField>
@@ -140,14 +132,12 @@ client.active_user.get_projects(
   Filter criteria. See [UserProjectsFilter](#userprojectsfilter)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="projects" type="ResourceCollection[Project]">
   Collection of projects
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 # Get all your projects
 projects = client.active_user.get_projects(limit=50)
@@ -161,8 +151,7 @@ if projects.cursor:
     next_page = client.active_user.get_projects(cursor=projects.cursor)
 ```
 
-**With Filtering:**
-
+With Filtering:
 ```python lines icon="python"
 See [UserProjectsFilter](#userprojectsfilter) for filtering options.
 ```
@@ -180,8 +169,7 @@ client.active_user.get_projects_with_permissions(
 ) -> ResourceCollection[ProjectWithPermissions]
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="limit" type="int" default="25">
   Maximum number of projects to return
 </ResponseField>
@@ -194,14 +182,12 @@ client.active_user.get_projects_with_permissions(
   Filter criteria. See [UserProjectsFilter](#userprojectsfilter)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="projects" type="ResourceCollection[ProjectWithPermissions]">
   Projects with permissions
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 projects = client.active_user.get_projects_with_permissions(limit=10)
 
@@ -236,14 +222,12 @@ client.active_user.get_project_invites() -> List[PendingStreamCollaborator]
 
 **Parameters:** None
 
-**Returns:**
-
+Returns:
 <ResponseField name="invites" type="List[PendingStreamCollaborator]">
   List of pending invitations
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 invites = client.active_user.get_project_invites()
 
@@ -273,15 +257,13 @@ client.active_user.can_create_personal_projects() -> PermissionCheckResult
 
 **Parameters:** None
 
-**Returns:**
-
+Returns:
 <ResponseField name="permission" type="PermissionCheckResult">
   Permission check result. See
   [PermissionCheckResult](/developers/sdks/python/api-reference/resources/project#permissioncheckresult)
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 permission = client.active_user.can_create_personal_projects()
 
@@ -310,8 +292,7 @@ client.active_user.get_workspaces(
 ) -> ResourceCollection[Workspace]
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="limit" type="int" default="25">
   Maximum number of workspaces to return
 </ResponseField>
@@ -324,14 +305,12 @@ client.active_user.get_workspaces(
   Filter criteria. See [UserWorkspacesFilter](#userworkspacesfilter)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="workspaces" type="ResourceCollection[Workspace]">
   Collection of workspaces
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 workspaces = client.active_user.get_workspaces()
 
@@ -362,14 +341,12 @@ client.active_user.get_active_workspace() -> Optional[LimitedWorkspace]
 
 **Parameters:** None
 
-**Returns:**
-
+Returns:
 <ResponseField name="workspace" type="LimitedWorkspace | None">
   Active workspace, or `None` if none selected
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 active_workspace = client.active_user.get_active_workspace()
 
@@ -478,8 +455,7 @@ UserUpdateInput(
 
 Used with [`update()`](#update).
 
-**Fields:**
-
+Fields:
 - `avatar` (str, optional) - Avatar image URL
 - `bio` (str, optional) - User biography
 - `company` (str, optional) - Company name
@@ -501,8 +477,7 @@ UserProjectsFilter(
 
 Used with [`get_projects()`](#get_projects) and [`get_projects_with_permissions()`](#get_projects_with_permissions).
 
-**Fields:**
-
+Fields:
 - `search` (str, optional) - Search by project name or description
 - `only_with_roles` (List[str], optional) - Filter by user roles
 - `workspace_id` (str, optional) - Filter to specific workspace
@@ -519,8 +494,7 @@ UserWorkspacesFilter(
 
 Used with [`get_workspaces()`](#get_workspaces).
 
-**Fields:**
-
+Fields:
 - `search` (str, optional) - Search by workspace name
 
 ## Related Resources

--- a/developers/sdks/python/api-reference/resources/model.mdx
+++ b/developers/sdks/python/api-reference/resources/model.mdx
@@ -29,8 +29,7 @@ Get a single model by ID.
 client.model.get(model_id: str, project_id: str) -> Model
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="model_id" type="str" required>
   The ID of the model to retrieve
 </ResponseField>
@@ -39,14 +38,12 @@ client.model.get(model_id: str, project_id: str) -> Model
   The ID of the project containing the model
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="model" type="Model">
   The model object
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 model = client.model.get("model_abc123", "project_xyz789")
 
@@ -77,8 +74,7 @@ client.model.get_models(
 ) -> ResourceCollection[Model]
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="project_id" type="str" required>
   The ID of the project
 </ResponseField>
@@ -95,14 +91,12 @@ client.model.get_models(
   Filter criteria. See [ProjectModelsFilter](#projectmodelsfilter)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="models" type="ResourceCollection[Model]">
   Collection with `items`, `totalCount`, and `cursor`
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 # Get all models in a project
 models = client.model.get_models("project_id", models_limit=50)
@@ -143,8 +137,7 @@ client.model.get_with_versions(
 ) -> ModelWithVersions
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="model_id" type="str" required>
   The ID of the model
 </ResponseField>
@@ -165,14 +158,12 @@ client.model.get_with_versions(
   Filter criteria for versions. See [ModelVersionsFilter](#modelversionsfilter)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="model" type="ModelWithVersions">
   Model with versions collection
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 # Get model with its latest 10 versions
 model = client.model.get_with_versions(
@@ -193,8 +184,7 @@ for version in model.versions.items:
 
 See [ModelVersionsFilter](#modelversionsfilter) for filtering options.
 
-**Pagination:**
-
+Pagination:
 ```python lines icon="python"
 # Get all versions (paginated)
 all_versions = []
@@ -225,20 +215,17 @@ Create a new model in a project.
 client.model.create(input: CreateModelInput) -> Model
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="CreateModelInput" required>
   Model creation parameters. See [CreateModelInput](#createmodelinput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="model" type="Model">
   The newly created model
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.model_inputs import CreateModelInput
 
@@ -254,8 +241,7 @@ print(f"Created model: {model.displayName} (ID: {model.id})")
 
 See [CreateModelInput](#createmodelinput) for all available fields.
 
-**Advanced Example:**
-
+Advanced Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.model_inputs import CreateModelInput
 
@@ -287,20 +273,17 @@ Update an existing model's properties.
 client.model.update(input: UpdateModelInput) -> Model
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="UpdateModelInput" required>
   Model update parameters. See [UpdateModelInput](#updatemodelinput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="model" type="Model">
   The updated model
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.model_inputs import UpdateModelInput
 
@@ -326,20 +309,17 @@ Delete a model permanently.
 client.model.delete(input: DeleteModelInput) -> bool
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="DeleteModelInput" required>
   Model deletion parameters. See [DeleteModelInput](#deletemodelinput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="success" type="bool">
   `True` if deletion was successful
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.model_inputs import DeleteModelInput
 
@@ -355,8 +335,7 @@ else:
     print("✗ Failed to delete model")
 ```
 
-**DeleteModelInput Fields:**
-
+DeleteModelInput Fields:
 - `projectId` (str, required) - The project ID
 - `modelId` (str, required) - The model ID to delete
 
@@ -418,8 +397,7 @@ CreateModelInput(
 
 Used with [`create()`](#create).
 
-**Fields:**
-
+Fields:
 - `name` (str) - Model name
 - `description` (str, optional) - Model description
 - `project_id` (str) - Project ID
@@ -437,8 +415,7 @@ UpdateModelInput(
 
 Used with [`update()`](#update).
 
-**Fields:**
-
+Fields:
 - `id` (str) - Model ID
 - `name` (str, optional) - New model name
 - `description` (str, optional) - New description
@@ -455,8 +432,7 @@ DeleteModelInput(
 
 Used with [`delete()`](#delete).
 
-**Fields:**
-
+Fields:
 - `id` (str) - Model ID
 - `project_id` (str) - Project ID
 
@@ -477,8 +453,7 @@ ProjectModelsFilter(
 
 Used with [`get_models()`](#get_models) and `client.project.get_with_models()`.
 
-**Fields:**
-
+Fields:
 - `contributors` (List[str], optional) - Filter by contributor user IDs
 - `exclude_ids` (List[str], optional) - Exclude specific model IDs
 - `ids` (List[str], optional) - Include only specific model IDs
@@ -497,8 +472,7 @@ ModelVersionsFilter(
 
 Used with [`get_with_versions()`](#get_with_versions).
 
-**Fields:**
-
+Fields:
 - `priority_ids` (List[str]) - Version IDs to prioritize
 - `priority_ids_only` (bool, optional) - Only return priority versions
 

--- a/developers/sdks/python/api-reference/resources/other-user.mdx
+++ b/developers/sdks/python/api-reference/resources/other-user.mdx
@@ -29,20 +29,17 @@ Get public profile information for another user by their ID.
 client.other_user.get(id: str) -> Optional[LimitedUser]
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="id" type="str" required>
   The ID of the user to retrieve
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="user" type="LimitedUser | None">
   The user's public profile, or `None` if not found
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 user = client.other_user.get("other_user_id_here")
 
@@ -77,8 +74,7 @@ client.other_user.user_search(
 ) -> UserSearchResultCollection
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="query" type="str" required>
   Search query (minimum 3 characters)
 </ResponseField>
@@ -99,14 +95,12 @@ client.other_user.user_search(
   Search email addresses only
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="results" type="UserSearchResultCollection">
   Search results with pagination cursor
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 # Search for users by name
 results = client.other_user.user_search("john", limit=10)
@@ -125,8 +119,7 @@ if results.cursor:
     )
 ```
 
-**Search by Email:**
-
+Search by Email:
 ```python lines icon="python"
 # Search email addresses only
 results = client.other_user.user_search(

--- a/developers/sdks/python/api-reference/resources/project.mdx
+++ b/developers/sdks/python/api-reference/resources/project.mdx
@@ -29,20 +29,17 @@ Get a single project by ID.
 client.project.get(project_id: str) -> Project
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="project_id" type="str" required>
   The ID of the project to retrieve
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="project" type="Project">
   The project object
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 project = client.project.get("abc123def456")
 
@@ -63,20 +60,17 @@ Get permission checks for a project.
 client.project.get_permissions(project_id: str) -> ProjectPermissionChecks
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="project_id" type="str" required>
   The ID of the project
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="permissions" type="ProjectPermissionChecks">
   Permission check results
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 permissions = client.project.get_permissions("project_id")
 
@@ -108,8 +102,7 @@ client.project.get_with_models(
 ) -> ProjectWithModels
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="project_id" type="str" required>
   The ID of the project
 </ResponseField>
@@ -126,14 +119,12 @@ client.project.get_with_models(
   Filter criteria for models. See [ProjectModelsFilter](#projectmodelsfilter)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="project" type="ProjectWithModels">
   Project with models collection
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 # Get project with first 10 models
 project = client.project.get_with_models(
@@ -165,20 +156,17 @@ Get a project with its team members and pending invitations.
 client.project.get_with_team(project_id: str) -> ProjectWithTeam
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="project_id" type="str" required>
   The ID of the project
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="project" type="ProjectWithTeam">
   Project with team information
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 project = client.project.get_with_team("project_id")
 
@@ -202,20 +190,17 @@ Create a new personal project (non-workspace).
 client.project.create(input: ProjectCreateInput) -> Project
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="ProjectCreateInput" required>
   Project creation parameters. See [ProjectCreateInput](#projectcreateinput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="project" type="Project">
   The newly created project
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.project_inputs import ProjectCreateInput
 
@@ -244,21 +229,18 @@ Create a new workspace project.
 client.project.create_in_workspace(input: WorkspaceProjectCreateInput) -> Project
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="WorkspaceProjectCreateInput" required>
   Workspace project creation parameters. See
   [WorkspaceProjectCreateInput](#workspaceprojectcreateinput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="project" type="Project">
   The newly created workspace project
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.project_inputs import WorkspaceProjectCreateInput
 
@@ -293,20 +275,17 @@ Update an existing project.
 client.project.update(input: ProjectUpdateInput) -> Project
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="ProjectUpdateInput" required>
   Project update parameters. See [ProjectUpdateInput](#projectupdateinput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="project" type="Project">
   The updated project
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.project_inputs import ProjectUpdateInput
 
@@ -332,20 +311,17 @@ Delete a project permanently.
 client.project.delete(project_id: str) -> bool
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="project_id" type="str" required>
   The ID of the project to delete
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="success" type="bool">
   `True` if deletion was successful
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 # Delete a project
 success = client.project.delete("project_id")
@@ -369,20 +345,17 @@ Update a team member's role in the project.
 client.project.update_role(input: ProjectUpdateRoleInput) -> ProjectWithTeam
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="ProjectUpdateRoleInput" required>
   Role update parameters
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="project" type="ProjectWithTeam">
   Updated project with team information
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.project_inputs import ProjectUpdateRoleInput
 
@@ -398,14 +371,12 @@ for member in project.team:
     print(f"  - {member.user.name}: {member.role}")
 ```
 
-**ProjectUpdateRoleInput Fields:**
-
+ProjectUpdateRoleInput Fields:
 - `projectId` (str, required) - The project ID
 - `userId` (str, required) - The user ID whose role to update
 - `role` (str, required) - New role: `"stream:owner"`, `"stream:contributor"`, or `"stream:reviewer"`
 
-**Role Permissions:**
-
+Role Permissions:
 - `stream:owner` - Full control, can delete project and manage team
 - `stream:contributor` - Can create models and versions
 - `stream:reviewer` - Read-only access
@@ -486,8 +457,7 @@ ProjectCreateInput(
 
 Used with [`create()`](#create).
 
-**Fields:**
-
+Fields:
 - `name` (str) - Project name
 - `description` (str, optional) - Project description
 - `visibility` (str, optional) - `"PRIVATE"`, `"PUBLIC"`, or `"UNLISTED"`
@@ -506,8 +476,7 @@ ProjectUpdateInput(
 
 Used with [`update()`](#update).
 
-**Fields:**
-
+Fields:
 - `id` (str) - Project ID
 - `name` (str, optional) - New project name
 - `description` (str, optional) - New description
@@ -527,8 +496,7 @@ WorkspaceProjectCreateInput(
 
 Used with [`create_in_workspace()`](#create_in_workspace).
 
-**Fields:**
-
+Fields:
 - `name` (str) - Project name
 - `description` (str, optional) - Project description
 - `visibility` (str, optional) - `"PRIVATE"`, `"PUBLIC"`, or `"UNLISTED"`
@@ -551,8 +519,7 @@ ProjectModelsFilter(
 
 Used with [`get_with_models()`](#get_with_models) and `client.model.get_models()`.
 
-**Fields:**
-
+Fields:
 - `contributors` (List[str], optional) - Filter by contributor user IDs
 - `exclude_ids` (List[str], optional) - Exclude specific model IDs
 - `ids` (List[str], optional) - Include only specific model IDs

--- a/developers/sdks/python/api-reference/resources/server.mdx
+++ b/developers/sdks/python/api-reference/resources/server.mdx
@@ -28,14 +28,12 @@ client.server.get() -> ServerInfo
 
 **Parameters:** None
 
-**Returns:**
-
+Returns:
 <ResponseField name="info" type="ServerInfo">
   Server information object
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 info = client.server.get()
 
@@ -63,15 +61,13 @@ client.server.version() -> Tuple[Any, ...]
 
 **Parameters:** None
 
-**Returns:**
-
+Returns:
 <ResponseField name="version" type="Tuple">
   Version tuple in format `(major, minor, patch)` or `(major, minor, patch, tag,
   build)` for pre-release versions
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 version = client.server.version()
 
@@ -98,14 +94,12 @@ client.server.apps() -> Dict
 
 **Parameters:** None
 
-**Returns:**
-
+Returns:
 <ResponseField name="apps" type="Dict">
   Dictionary of registered apps
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 apps = client.server.apps()
 
@@ -132,8 +126,7 @@ client.server.create_token(
 ) -> str
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="name" type="str" required>
   A descriptive name for the token
 </ResponseField>
@@ -146,8 +139,7 @@ client.server.create_token(
   Token lifespan in seconds
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="token" type="str">
   The newly created token string
 </ResponseField>
@@ -156,8 +148,7 @@ client.server.create_token(
   The token is only shown once when created. Store it securely immediately!
 </Warning>
 
-**Example:**
-
+Example:
 ```python
 # Create a token with specific scopes
 token = client.server.create_token(
@@ -175,8 +166,7 @@ with open('.env', 'a') as f:
     f.write(f'\nSPECKLE_TOKEN={token}\n')
 ```
 
-**Common Scopes:**
-
+Common Scopes:
 - `streams:read` - Read project/stream data
 - `streams:write` - Write project/stream data
 - `profile:read` - Read user profile
@@ -195,20 +185,17 @@ Revoke (delete) a personal API token.
 client.server.revoke_token(token: str) -> bool
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="token" type="str" required>
   The token string to revoke
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="success" type="bool">
   `True` if the token was successfully revoked
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 # Revoke a token
 token_to_revoke = "abc123def456..."

--- a/developers/sdks/python/api-reference/resources/version.mdx
+++ b/developers/sdks/python/api-reference/resources/version.mdx
@@ -29,8 +29,7 @@ Get a single version by ID.
 client.version.get(version_id: str, project_id: str) -> Version
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="version_id" type="str" required>
   The ID of the version to retrieve
 </ResponseField>
@@ -39,14 +38,12 @@ client.version.get(version_id: str, project_id: str) -> Version
   The ID of the project containing the version
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="version" type="Version">
   The version object
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 version = client.version.get("version_abc123", "project_xyz789")
 
@@ -74,8 +71,7 @@ client.version.get_versions(
 ) -> ResourceCollection[Version]
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="model_id" type="str" required>
   The ID of the model
 </ResponseField>
@@ -96,14 +92,12 @@ client.version.get_versions(
   Filter criteria
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="versions" type="ResourceCollection[Version]">
   Collection with `items`, `totalCount`, and `cursor`
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 # Get latest 25 versions
 versions = client.version.get_versions("model_id", "project_id")
@@ -114,8 +108,7 @@ for version in versions.items:
     print(f"    Created: {version.createdAt}")
 ```
 
-**With Pagination:**
-
+With Pagination:
 ```python lines icon="python"
 # Get all versions (paginated)
 all_versions = []
@@ -138,8 +131,7 @@ while True:
 print(f"Retrieved {len(all_versions)} versions total")
 ```
 
-**With Filtering:**
-
+With Filtering:
 ```python lines icon="python"
 from specklepy.core.api.inputs.model_inputs import ModelVersionsFilter
 
@@ -168,20 +160,17 @@ Create a new version in a model.
 client.version.create(input: CreateVersionInput) -> Version
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="CreateVersionInput" required>
   Version creation parameters. See [CreateVersionInput](#createversioninput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="version" type="Version">
   The newly created version
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.version_inputs import CreateVersionInput
 
@@ -198,16 +187,14 @@ print(f"Created version: {version.id}")
 print(f"Message: {version.message}")
 ```
 
-**CreateVersionInput Fields:**
-
+CreateVersionInput Fields:
 - `project_id` (str, required) - The project ID
 - `model_id` (str, required) - The model ID
 - `object_id` (str, required) - The ID of the object to reference (from `operations.send()`)
 - `message` (str, optional) - Commit message describing this version
 - `source_application` (str, optional) - Name of the source application
 
-**Complete Workflow Example:**
-
+Complete Workflow Example:
 ```python lines icon="python"
 from specklepy.api import operations
 from specklepy.transports.server import ServerTransport
@@ -240,20 +227,17 @@ Update an existing version's properties.
 client.version.update(input: UpdateVersionInput) -> Version
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="UpdateVersionInput" required>
   Version update parameters. See [UpdateVersionInput](#updateversioninput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="version" type="Version">
   The updated version
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.version_inputs import UpdateVersionInput
 
@@ -280,20 +264,17 @@ Move versions from one model to another within the same project.
 client.version.move_to_model(input: MoveVersionsInput) -> str
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="MoveVersionsInput" required>
   Move parameters. See [MoveVersionsInput](#moveversionsinput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="model_id" type="str">
   The target model ID
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.version_inputs import MoveVersionsInput
 
@@ -307,8 +288,7 @@ target_model_id = client.version.move_to_model(MoveVersionsInput(
 print(f"✓ Moved 3 versions to model: {target_model_id}")
 ```
 
-**MoveVersionsInput Fields:**
-
+MoveVersionsInput Fields:
 - `project_id` (str, required) - The project ID
 - `version_ids` (List[str], required) - List of version IDs to move
 - `target_model_id` (str, required) - The destination model ID
@@ -324,20 +304,17 @@ Delete one or more versions permanently.
 client.version.delete(input: DeleteVersionsInput) -> bool
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="DeleteVersionsInput" required>
   Deletion parameters. See [DeleteVersionsInput](#deleteversionsinput)
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="success" type="bool">
   `True` if deletion was successful
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.version_inputs import DeleteVersionsInput
 
@@ -353,8 +330,7 @@ else:
     print("✗ Failed to delete versions")
 ```
 
-**DeleteVersionsInput Fields:**
-
+DeleteVersionsInput Fields:
 - `project_id` (str, required) - The project ID
 - `version_ids` (List[str], required) - List of version IDs to delete
 
@@ -369,20 +345,17 @@ Mark a version as received (useful for tracking which versions have been process
 client.version.received(input: MarkReceivedVersionInput) -> bool
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="input" type="MarkReceivedVersionInput" required>
   Mark received parameters
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="success" type="bool">
   `True` if successfully marked
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.core.api.inputs.version_inputs import MarkReceivedVersionInput
 from specklepy.api import operations
@@ -403,8 +376,7 @@ if success:
     print("✓ Marked version as received")
 ```
 
-**MarkReceivedVersionInput Fields:**
-
+MarkReceivedVersionInput Fields:
 - `project_id` (str, required) - The project ID
 - `version_id` (str, required) - The version ID to mark
 - `message` (str, optional) - Optional message
@@ -464,7 +436,7 @@ CreateVersionInput(
 
 Used with [`create()`](#create).
 
-**Fields:**
+Fields:
 - `object_id` (str) - ID of the object (from `operations.send()`)
 - `model_id` (str) - Model ID
 - `project_id` (str) - Project ID
@@ -484,7 +456,7 @@ UpdateVersionInput(
 
 Used with [`update()`](#update).
 
-**Fields:**
+Fields:
 - `version_id` (str) - Version ID
 - `project_id` (str) - Project ID
 - `message` (str, optional) - New version message
@@ -499,7 +471,7 @@ DeleteVersionsInput(
 
 Used with [`delete()`](#delete).
 
-**Fields:**
+Fields:
 - `version_ids` (List[str]) - List of version IDs to delete
 - `project_id` (str) - Project ID
 ### MoveVersionsInput
@@ -514,7 +486,7 @@ MoveVersionsInput(
 
 Move versions to a different model.
 
-**Fields:**
+Fields:
 - `target_model_name` (str) - Name of the target model
 - `version_ids` (List[str]) - Version IDs to move
 - `project_id` (str) - Project ID

--- a/developers/sdks/python/api-reference/resources/workspace.mdx
+++ b/developers/sdks/python/api-reference/resources/workspace.mdx
@@ -4,8 +4,7 @@ description: 'API reference for workspace operations in SpecklePy'
 ---
 
 <Warning>
-**Hosted Server Feature**
-
+Hosted Server Feature:
 The `WorkspaceResource` is only available on workspace-enabled Speckle deployments, primarily the hosted server at **app.speckle.systems**.
 
 **Self-hosted/open-source server deployments do not include workspace features.** Attempting to use workspace methods on non-workspace servers will raise an error.
@@ -37,20 +36,17 @@ Get a single workspace by ID.
 client.workspace.get(workspace_id: str) -> Workspace
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="workspace_id" type="str" required>
   The ID of the workspace to retrieve
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="workspace" type="Workspace">
   The workspace object
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 workspace = client.workspace.get("workspace_abc123")
 
@@ -79,8 +75,7 @@ client.workspace.get_projects(
 ) -> ResourceCollection[Project]
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="workspace_id" type="str" required>
   The ID of the workspace
 </ResponseField>
@@ -97,14 +92,12 @@ client.workspace.get_projects(
   Filter criteria
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="projects" type="ResourceCollection[Project]">
   Collection with `items`, `totalCount`, and `cursor`
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 projects = client.workspace.get_projects("workspace_id", limit=50)
 
@@ -119,8 +112,7 @@ if projects.cursor:
     next_page = client.workspace.get_projects("workspace_id", cursor=projects.cursor)
 ```
 
-**Filter Example:**
-
+Filter Example:
 ```python
 from specklepy.core.api.inputs.project_inputs import WorkspaceProjectsFilter
 
@@ -147,8 +139,7 @@ client.workspace.get_projects_with_permissions(
 ) -> ResourceCollection[ProjectWithPermissions]
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="workspace_id" type="str" required>
   The ID of the workspace
 </ResponseField>
@@ -165,14 +156,12 @@ client.workspace.get_projects_with_permissions(
   Filter criteria
 </ResponseField>
 
-**Returns:**
-
+Returns:
 <ResponseField name="projects" type="ResourceCollection[ProjectWithPermissions]">
   Collection of projects with permission details
 </ResponseField>
 
-**Example:**
-
+Example:
 ```python
 projects = client.workspace.get_projects_with_permissions("workspace_id")
 
@@ -189,8 +178,7 @@ for project in projects.items:
         print("  ✓ Can publish versions")
 ```
 
-**ProjectWithPermissions Additional Properties:**
-
+ProjectWithPermissions Additional Properties:
 - `permissions` (ProjectPermissions) - Detailed permission checks
   - `canCreateModel` - Model creation permission
   - `canDelete` - Project deletion permission
@@ -266,8 +254,7 @@ WorkspaceProjectsFilter(
 
 Used with [`get_projects()`](#get_projects) and [`get_projects_with_permissions()`](#get_projects_with_permissions).
 
-**Fields:**
-
+Fields:
 - `search` (str, optional) - Filter by project name
 - `with_project_role_only` (bool, optional) - Only return projects where user has explicit project role
 

--- a/developers/sdks/python/api-reference/transports.mdx
+++ b/developers/sdks/python/api-reference/transports.mdx
@@ -30,8 +30,7 @@ ServerTransport(
 )
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="stream_id" type="str" required>
   Project ID
 </ResponseField>
@@ -78,12 +77,12 @@ obj = operations.receive(object_id, remote_transport=transport)
 
 ### Authentication Options
 
-**Using Client (Recommended):**
+Using Client (Recommended):
 ```python
 transport = ServerTransport(stream_id="project_id", client=client)
 ```
 
-**Using Token:**
+Using Token:
 ```python
 transport = ServerTransport(
     stream_id="project_id",
@@ -92,7 +91,7 @@ transport = ServerTransport(
 )
 ```
 
-**Using Account:**
+Using Account:
 ```python
 from specklepy.api.credentials import get_default_account
 
@@ -109,7 +108,7 @@ from specklepy.transports.memory import MemoryTransport
 transport = MemoryTransport()
 ```
 
-**Properties:**
+Properties:
 - `objects` (Dict[str, str]) - Dictionary of stored objects
 - `saved_object_count` (int) - Number of objects saved
 
@@ -129,8 +128,7 @@ transport = SQLiteTransport(
 )
 ```
 
-**Parameters:**
-
+Parameters:
 <ResponseField name="base_path" type="str" default="None">
   Custom directory for database
 </ResponseField>
@@ -147,12 +145,12 @@ transport = SQLiteTransport(
   Batch size in MB
 </ResponseField>
 
-**Database location:**
+Database location:
 - Windows: `%APPDATA%\{app_name}\{scope}.db`
 - macOS: `~/Library/Application Support/{app_name}/{scope}.db`
 - Linux: `~/.config/{app_name}/{scope}.db`
 
-**Use cases:**
+Use cases:
 - Local caching of server data
 - Offline workflows
 - Persistent local storage

--- a/developers/sdks/python/concepts/data-traversal.mdx
+++ b/developers/sdks/python/concepts/data-traversal.mdx
@@ -18,8 +18,7 @@ Speckle objects form hierarchical graphs - tree-like structures where objects co
 - Filter data based on properties or structure
 - Build analysis pipelines that understand object hierarchies
 
-**Key Concepts:**
-
+Key Concepts:
 - **Graph Structure**: Objects are connected through properties (parent → child relationships)
 - **Traversal**: The process of visiting every object in a graph systematically
 - **Filtering**: Selecting only objects that match specific criteria during traversal
@@ -118,19 +117,19 @@ Different data structures require different traversal strategies:
 
 **When to use:** Working with BIM data from connectors (Revit, Rhino, ArchiCAD, etc.).
 
-**How it works:**
+How it works:
 - Traverse recursively
 - Check if object has a `properties` dictionary
 - Filter based on property values (e.g., `category == "Walls"`)
 - Collect matching objects
 
-**Best for:**
+Best for:
 - v3 BIM objects (DataObject)
 - Finding objects by category, family, type
 - Filtering by quantities or metadata
 - Most common pattern for modern Speckle data
 
-**Example use cases:**
+Example use cases:
 - "Find all walls" → filter by `properties.category == "Walls"`
 - "Get steel beams" → filter by `properties.category == "Structural Framing"` AND `properties.material == "Steel"`
 - "Objects on Level 1" → filter by `properties.level == "Level 1"`
@@ -139,12 +138,12 @@ Different data structures require different traversal strategies:
 
 **When to use:** You only want atomic, viewer-selectable objects.
 
-**How it works:**
+How it works:
 - Traverse recursively
 - Collect only objects with a `displayValue` property
 - These are the objects that appear as selectable items in the viewer
 
-**Best for:**
+Best for:
 - Getting viewer-clickable objects
 - Counting actual BIM elements (not containers/groups)
 - Extracting geometry for visualization
@@ -160,13 +159,13 @@ Different data structures require different traversal strategies:
 The `elements` property is Speckle's standardized convention for organizing hierarchical data. See [The elements Convention](/developers/sdks/python/concepts/data-types#the-elements-convention) for a detailed explanation of this pattern.
 </Info>
 
-**How it works:**
+How it works:
 - Check if object has an `elements` property (list)
 - Recursively traverse only the elements array
 - Optionally filter during traversal
 - Ignores other properties
 
-**Best for:**
+Best for:
 - Collections and Groups
 - Organized BIM hierarchies (Level → Room → Elements)
 - When you only care about the logical organization, not nested geometry
@@ -177,13 +176,13 @@ The `elements` property is Speckle's standardized convention for organizing hier
 
 **When to use:** You need to visit EVERY object in the graph, regardless of type or depth.
 
-**How it works:**
+How it works:
 - Start at root object
 - Visit each property on the object
 - For each property that's a Base object, list, or dict, recurse into it
 - Continue until all branches are explored
 
-**Best for:**
+Best for:
 - Finding rare objects that could be anywhere
 - Building complete inventories
 - Ensuring nothing is missed
@@ -194,13 +193,13 @@ The `elements` property is Speckle's standardized convention for organizing hier
 
 **When to use:** Looking for geometry primitives (Mesh, Point, Line, etc.).
 
-**How it works:**
+How it works:
 - Traverse recursively
 - Check each object's `speckle_type` property
 - Collect only objects matching the target type
 - Continue traversing to find all instances
 
-**Best for:**
+Best for:
 - Finding geometry objects (Mesh, Line, Point, Arc, Circle, etc.)
 - Pure geometry workflows
 - Legacy v2 objects with typed BIM classes
@@ -357,13 +356,13 @@ print(f"Found {len(walls)} walls")
 
 **Purpose:** Search for objects based on their properties (the standard v3 pattern).
 
-**When to use:** 
+When to use:
 - Working with BIM data from any connector (Revit, Rhino, ArchiCAD, etc.)
 - Need to find objects by category, family, type, level, material
 - Filtering by quantities, parameters, or metadata
 - **This is the primary pattern for modern Speckle data**
 
-**How it works:**
+How it works:
 1. Recursively traverse all objects
 2. Check if object has `properties` dictionary
 3. Filter based on property values
@@ -371,19 +370,19 @@ print(f"Found {len(walls)} walls")
 
 **Purpose:** Find objects based on their properties dictionary values (v3 BIM pattern).
 
-**When to use:**
+When to use:
 - Working with v3 BIM data (DataObject)
 - Need to find objects by category ("Walls", "Columns", "Floors")
 - Filtering by BIM properties (loadBearing, fireRating, family, type)
 - Need to find objects with specific quantities or metadata
 
-**Advantages:**
+Advantages:
 - Works with v3 object model
 - Can filter on any property value
 - Can combine multiple property conditions
 - Reflects how BIM data is actually organized
 
-**How it works:**
+How it works:
 1. Traverse all objects
 2. Check if object is a DataObject
 3. Access the `properties` dictionary
@@ -441,12 +440,12 @@ print(f"Objects with volume: {len(all_with_volume)}")
 
 **Purpose:** Search for geometry primitives by `speckle_type`.
 
-**When to use:** 
+When to use:
 - Looking for geometry objects (Mesh, Point, Line, Arc, Circle, etc.)
 - Pure geometry workflows without BIM semantics
 - Need to find all instances of a specific geometry class
 
-**When NOT to use:**
+When NOT to use:
 - ❌ BIM data from connectors (use Pattern 1 - Find by Property instead)
 - ❌ Need to differentiate walls from columns (use properties)
 - ❌ Any data where semantics are in the properties dictionary
@@ -500,24 +499,24 @@ print(f"Found {len(points)} points, {len(meshes)} meshes, {len(lines)} lines")
 
 **Purpose:** Convert hierarchical object graphs into flat lists for easier processing.
 
-**When to use:**
+When to use:
 - Need to process all objects of a certain type
 - Want to use list operations (filter, map, sort)
 - Building dataframes or CSV exports
 - Running aggregate calculations (sum, average, count)
 
-**Advantages:**
+Advantages:
 - Easier to work with than nested structures
 - Can use standard Python list operations
 - Simple to convert to pandas DataFrame
 - Good for batch processing
 
-**Disadvantages:**
+Disadvantages:
 - Loses hierarchical relationships
 - Can be memory-intensive for large models
 - May include objects you don't need
 
-**How it works:**
+How it works:
 1. Start with empty results list
 2. Traverse entire object graph
 3. Collect objects matching criteria
@@ -582,8 +581,7 @@ meshes = flatten_geometry(obj, Mesh)
 points = flatten_geometry(obj, Point)
 ```
 
-**Alternative: Property-based flattening (most flexible)**
-
+Alternative: Property-based flattening (most flexible):
 ```python lines icon="python"
 def flatten_by_properties(root, **filters):
     """Build a flat list of DataObjects by category (for v3 BIM objects)."""
@@ -621,13 +619,13 @@ print(f"Found {len(all_walls)} walls, {len(all_columns)} columns")
 
 **Purpose:** Navigate object hierarchies by following the organizational structure defined by `elements[]` arrays.
 
-**When to use:**
+When to use:
 - Data is organized in Collections or Groups
 - Objects have a logical hierarchy (Building → Level → Room → Elements)
 - Want to respect the intentional organization
 - Need faster traversal by ignoring non-structural properties
 
-**How it works:**
+How it works:
 1. Check if object has `elements` property (list)
 2. Recursively traverse only through elements arrays
 3. Optionally filter during traversal
@@ -638,7 +636,7 @@ print(f"Found {len(all_walls)} walls, {len(all_columns)} columns")
 - **Group** objects organize related objects in `elements`
 - **Level** hierarchies nest objects in `elements`
 
-**Advantages:**
+Advantages:
 - Faster than full traversal
 - Follows logical organization
 - Respects data structure intent
@@ -696,7 +694,7 @@ print(f"Load bearing elements: {len(load_bearing)}")
 
 **Purpose:** Find only atomic, viewer-selectable objects by filtering for `displayValue` presence.
 
-**When to use:**
+When to use:
 - Need to count actual BIM elements (not containers or groups)
 - Want objects that appear as selectable items in the viewer
 - Building element lists for UI selection
@@ -712,7 +710,7 @@ print(f"Load bearing elements: {len(load_bearing)}")
 **Why displayValue matters:** Objects with a `displayValue` property represent atomic, selectable items in the Speckle viewer. Each object with `displayValue` can be clicked, selected, and queried independently in the 3D view. The `displayValue` typically contains a list of `Mesh` objects that define the visual representation.
 </Info>
 
-**How it works:**
+How it works:
 1. Traverse the entire graph
 2. Check if object has `displayValue` property
 3. Verify `displayValue` is not None
@@ -772,13 +770,13 @@ for atomic_obj in atomic_objects[:5]:  # First 5
 
 **Purpose:** Efficiently find atomic BIM objects by combining structural traversal with displayValue filtering.
 
-**When to use:**
+When to use:
 - Large BIM models where full traversal is slow
 - Data is organized in elements[] hierarchy
 - Only want viewer-selectable objects
 - Need to skip containers and organizational objects
 
-**Advantages:**
+Advantages:
 - Faster than full traversal (follows elements[] only)
 - More precise than elements[] alone (filters to atomic objects)
 - Gets you exactly what users see in the viewer
@@ -786,7 +784,7 @@ for atomic_obj in atomic_objects[:5]:  # First 5
 
 **Key Optimization:** Objects with `displayValue` are typically **leaf nodes** - they don't have children with displayValues. This means you can stop traversing deeper once you find a displayValue, making traversal much more efficient.
 
-**Strategy:**
+Strategy:
 1. Traverse through elements[] arrays only (ignore other properties)
 2. At each object, check for displayValue
 3. Collect objects that have displayValue and STOP traversing deeper
@@ -837,21 +835,21 @@ for category, count in sorted(by_category.items()):
 
 **Purpose:** Organize flat lists of objects into groups based on shared property values.
 
-**When to use:**
+When to use:
 - Need to analyze objects by category, type, or level
 - Building summaries ("count by type")
 - Preparing data for reports or charts
 - Want to process each group separately
 - Need to find relationships between objects
 
-**Common groupings:**
+Common groupings:
 - By BIM category (Walls, Columns, Floors)
 - By level/storey ("Level 1", "Level 2")
 - By family or type
 - By material
 - By any property value
 
-**How it works:**
+How it works:
 1. First, flatten objects (Pattern 3)
 2. Iterate through flat list
 3. Extract grouping property from each object

--- a/developers/sdks/python/concepts/data-types.mdx
+++ b/developers/sdks/python/concepts/data-types.mdx
@@ -26,14 +26,13 @@ print(f"Properties: {obj.get_member_names()}")
 
 **What it is:** Data you create from scratch with your own structure.
 
-**Characteristics:**
+Characteristics:
 - Simple Base objects with custom properties
 - No connector-specific structure
 - Direct property access
 - Full control over schema
 
-**Example:**
-
+Example:
 ```python lines icon="python"
 from specklepy.objects import Base
 from specklepy.objects.geometry import Point
@@ -49,7 +48,7 @@ survey.points = [
 survey.notes = "Initial survey"
 ```
 
-**When you see it:**
+When you see it:
 - Python-to-Python workflows
 - Custom data pipelines
 - Analysis results you're sending
@@ -59,15 +58,14 @@ survey.notes = "Initial survey"
 
 **What it is:** Geometry with attached properties, typically from simple exports or scripts.
 
-**Characteristics:**
+Characteristics:
 - Geometry objects (Point, Line, Mesh)
 - Properties as dictionaries or direct attributes
 - Optional `displayValue` for visualization
 - Material and layer information
 - Moderate nesting (1-2 levels)
 
-**Example:**
-
+Example:
 ```json
 {
     "speckle_type": "Objects.Geometry.Mesh",
@@ -83,7 +81,7 @@ survey.notes = "Initial survey"
 }
 ```
 
-**When you see it:**
+When you see it:
 - Grasshopper exports
 - Rhino script outputs
 - Simple geometry with metadata
@@ -94,7 +92,7 @@ survey.notes = "Initial survey"
 
 **What it is:** Rich application data from BIM tools with complex nested structures.
 
-**Characteristics:**
+Characteristics:
 - Deep nesting (3+ levels)
 - Rich property collections
 - Display value proxies
@@ -102,8 +100,7 @@ survey.notes = "Initial survey"
 - Instance/definition patterns
 - Data chunk references
 
-**Example:**
-
+Example:
 ```json
 {
     "speckle_type": "Objects.Data.DataObject",
@@ -127,7 +124,7 @@ survey.notes = "Initial survey"
 }
 ```
 
-**When you see it:**
+When you see it:
 - Connector exports from any BIM authoring tool
 - Rhino exports with complex objects
 - ArchiCAD, Revit, Tekla exports
@@ -169,19 +166,19 @@ else:
 
 <Tabs>
   <Tab title="Structure">
-    **Custom Data:**
+    Custom Data:
     ```python lines icon="python"
     obj.myProperty  # Direct access
     obj.myList[0]   # Simple nesting
     ```
 
-    **Simple Model Data:**
+    Simple Model Data:
     ```python lines icon="python"
     obj.properties["Material"]  # Properties dict
     obj.displayValue.vertices   # Geometry access
     ```
 
-    **Complex BIM Data:**
+    Complex BIM Data:
     ```python lines icon="python"
     obj.properties["Volume"]  # Properties dict access
     obj.displayValue  # List of geometry representations
@@ -189,21 +186,21 @@ else:
   </Tab>
   
   <Tab title="Access Pattern">
-    **Custom Data:**
+    Custom Data:
     ```python lines icon="python"
     # You know the structure
     name = obj.name
     value = obj.measurements[0].value
     ```
 
-    **Simple Model Data:**
+    Simple Model Data:
     ```python lines icon="python"
     # Check for common properties
     if hasattr(obj, "properties"):
         material = obj.properties.get("Material")
     ```
 
-    **Complex BIM Data:**
+    Complex BIM Data:
     ```python lines icon="python"
     # Defensive traversal required
     properties = getattr(obj, "properties", {})
@@ -213,21 +210,21 @@ else:
   </Tab>
   
   <Tab title="Traversal">
-    **Custom Data:**
+    Custom Data:
     ```python lines icon="python"
     # Simple iteration
     for item in obj.items:
         process(item)
     ```
 
-    **Simple Model Data:**
+    Simple Model Data:
     ```python lines icon="python"
     # Check a few known properties
     if hasattr(obj, "displayValue"):
         mesh = obj.displayValue
     ```
 
-    **Complex BIM Data:**
+    Complex BIM Data:
     ```python lines icon="python"
     # Recursive traversal needed
     def traverse(obj):
@@ -265,8 +262,7 @@ else:
 
 Speckle uses a standardized convention for organizing hierarchical data: the **`elements`** property. This property has a special meaning and is the predictable way to traverse object hierarchies.
 
-**Key Concepts:**
-
+Key Concepts:
 - **Atomic Objects** - Objects that represent actual "things" (walls, beams, points, etc.)
 - **Property Objects** - Objects stored as properties for reference (materials, styles, etc.)
 - **Container Objects** - Objects that organize other objects via `elements`
@@ -292,8 +288,7 @@ project.elements = [
 ```
 
 <Info>
-**Why `elements`?** 
-
+Why `elements`?:
 While *any* property can technically contain Speckle objects, `elements` is the internal convention for managing hierarchy in a predictable way. This allows traversal code, connectors, and the viewer to consistently understand object relationships.
 
 Some typed properties also expect arrays of objects (like `displayValue`), but these serve different purposes - `displayValue` is for visualization, while `elements` is for logical hierarchy.
@@ -330,8 +325,7 @@ building.elements = [
 ]
 ```
 
-**Collection Properties:**
-
+Collection Properties:
 - `name` - Human-readable name (not necessarily unique)
 - `elements` - List of contained objects (can include nested Collections)
 - `applicationId` - Unique identifier for the collection
@@ -404,8 +398,7 @@ traverse_elements(project)
 ```
 
 <Warning>
-**Not all objects use `elements`**
-
+Not all objects use `elements`:
 Simple geometry objects (Point, Line, Mesh) typically don't have `elements` - they are leaf nodes. Always check `hasattr(obj, "elements")` before accessing it.
 </Warning>
 
@@ -445,21 +438,21 @@ for element in obj.elements:
 
 <CardGroup cols={3}>
   <Card title="Custom Data" icon="code">
-    **You create it**
+    You create it:
     - Direct access
     - Simple structure
     - Full control
   </Card>
   
   <Card title="Simple Model" icon="cube">
-    **Geometry + Props**
+    Geometry + Props:
     - Properties dict
     - DisplayValue
     - Moderate nesting
   </Card>
   
   <Card title="Complex BIM" icon="building">
-    **Rich BIM Data**
+    Rich BIM Data:
     - Deep nesting
     - Properties dict
     - Defensive code

--- a/developers/sdks/python/concepts/display-values.mdx
+++ b/developers/sdks/python/concepts/display-values.mdx
@@ -50,7 +50,7 @@ wall = DataObject(
 operations.send(wall, [transport])  # Visible and selectable!
 ```
 
-**Key principles:**
+Key principles:
 - Display values are **meshes** (triangulated geometry)
 - They're **viewer-ready** (no computation needed)
 - **Geometry primitives alone are NOT visible** (must be in displayValue)
@@ -77,7 +77,7 @@ revit_wall = DataObject(
 )
 ```
 
-**What happens:**
+What happens:
 - Connector reads native geometry (Revit solid, Rhino NURBS, etc.)
 - Converts to triangulated mesh(es)
 - Attaches as `displayValue` property
@@ -103,8 +103,7 @@ if hasattr(wall, "displayValue"):
 
 ### 3. Interoperability Achieved
 
-**Different sources, same viewer:**
-
+Different sources, same viewer:
 ```python
 # From Revit
 revit_wall.displayValue = [mesh_from_revit_solid]
@@ -142,7 +141,7 @@ complex_object = DataObject(
 )
 ```
 
-**Why multiple meshes:**
+Why multiple meshes:
 - Different materials per layer
 - Performance optimization (LOD levels)
 - Separate components for complex objects
@@ -164,7 +163,7 @@ display_mesh = Mesh(
 )
 ```
 
-**Mesh capabilities:**
+Mesh capabilities:
 - Triangulated or quad faces
 - Vertex colors for material visualization
 - Texture coordinates for mapped materials
@@ -183,7 +182,7 @@ rhino_brep.encodedValue = brep_native_data  # Rhino-specific (lossless)
 rhino_brep.displayValue = [mesh]  # Universal (viewer-ready)
 ```
 
-**Why both:**
+Why both:
 - **Display value** - Universal visualization (all viewers)
 - **Native geometry** - Lossless round-trip (same app)
 
@@ -213,7 +212,7 @@ selectable = [obj for obj in all_objects if is_viewer_selectable(obj)]
 print(f"Found {len(selectable)} objects visible in viewer")
 ```
 
-**Viewer interaction:**
+Viewer interaction:
 - Click to select → queries object with `displayValue`
 - Hover for info → shows object name and properties
 - Filter/isolate → based on objects with `displayValue`
@@ -238,7 +237,7 @@ wall = DataObject(
 )
 ```
 
-**Pattern:**
+Pattern:
 - **Containers** (levels, groups, collections) → No `displayValue`
 - **Elements** (walls, columns, furniture) → Has `displayValue`
 
@@ -248,8 +247,7 @@ wall = DataObject(
 **Key Principle:** Objects with `displayValue` typically don't have child elements that also have `displayValue`. Display values mark **leaf nodes** in the object graph - the atomic, indivisible elements that appear in the viewer.
 </Info>
 
-**Why this matters:**
-
+Why this matters:
 ```python
 # Typical structure - displayValue at leaves only
 building = Base(
@@ -279,8 +277,7 @@ wall_1 = DataObject(
 )
 ```
 
-**Exceptions are rare:**
-
+Exceptions are rare:
 ```python
 # Unusual but possible - nested displayValues
 assembly = DataObject(
@@ -295,7 +292,7 @@ assembly = DataObject(
 # This creates multiple selection levels in viewer (uncommon)
 ```
 
-**Design implications:**
+Design implications:
 - **Query optimization** - Find all viewer objects by looking for `displayValue`, stop traversing deeper
 - **Viewer selection** - Click selects the object with `displayValue`, not its parent
 - **Performance** - Limits recursion depth when rendering
@@ -484,7 +481,7 @@ object_id = operations.send(wall, [transport])
 # {"name": "Complex Wall", "displayValue": "hash-ref"}
 ```
 
-**Automatic optimization:**
+Automatic optimization:
 - SDK detects large `displayValue` meshes
 - Stores them separately in transport
 - Main object stays lightweight
@@ -610,7 +607,7 @@ beam.renderMaterial = steel_material  # Single material for all display meshes
 ```
 
 <Info>
-**RenderMaterial Properties:**
+RenderMaterial Properties:
 - `diffuse` - Base color (ARGB integer format: 0xAARRGGBB)
 - `metalness` - How metallic the surface appears (0.0-1.0)
 - `roughness` - Surface roughness for reflections (0.0-1.0)
@@ -646,8 +643,7 @@ root.colorProxies = [color_proxy]
 ```
 
 <Info>
-**ColorProxy and Viewer "Shaded" Mode**
-
+ColorProxy and Viewer "Shaded" Mode:
 ColorProxies enable the **"Shaded" view mode** in the Speckle viewer, which provides an alternative presentation of your model:
 
 - **Default rendering** - Shows objects with their native materials, textures, and per-vertex colors (the "raw" object appearance)
@@ -661,12 +657,12 @@ Think of it as switching between "what it looks like" and "how it's organized."
 </Info>
 
 <Note>
-**When consuming data from connectors:**
+When consuming data from connectors:
 - Connectors (Revit, Rhino, etc.) typically use proxies to organize materials
 - The viewer resolves these proxies to apply materials to objects
 - See [Proxification](/developers/sdks/python/concepts/proxification) for details on how proxies work
 
-**When creating data in Python:**
+When creating data in Python:
 - For simple cases, use per-vertex colors or direct `renderMaterial` property
 - Only use proxies if you need to organize many objects by shared materials
 </Note>
@@ -957,15 +953,14 @@ The viewer traverses the object graph looking for:
 
 If you send a Mesh directly, it has no `displayValue` property on itself, so the viewer doesn't know it's meant to be displayed.
 
-**Think of it this way:**
+Think of it this way:
 - **Mesh/Point/Line** = The paint/canvas (the geometry data)
 - **Object with displayValue** = The picture frame (makes it displayable)
 - **Viewer** = The art gallery (only hangs framed pictures)
 
 ## Summary
 
-**Display Values are the key to universal 3D interoperability:**
-
+Display Values are the key to universal 3D interoperability:
 - ✅ **Any connector can publish visible data** - Just attach tessellated meshes as displayValue
 - ✅ **Any viewer can render** - No knowledge of source application needed
 - ✅ **Objects are selectable and queryable** - Objects with `displayValue` are atomic viewer elements
@@ -978,8 +973,7 @@ Geometry primitives (Mesh, Point, Line) **MAY NOT BE VISIBLE** when sent directl
 Always wrap what you want shown in a DataObject or Base with a `displayValue` property. This is the most common mistake for new Speckle developers.
 </Warning>
 
-**Key Points:**
-
+Key Points:
 1. Display values are **tessellated meshes** attached to objects
 2. They enable **universal visualization** across all connectors
 3. Objects with `displayValue` are **selectable in the viewer**

--- a/developers/sdks/python/concepts/overview.mdx
+++ b/developers/sdks/python/concepts/overview.mdx
@@ -289,8 +289,7 @@ version = client.version.create(CreateVersionInput(
 ))
 ```
 
-**Key Points:**
-
+Key Points:
 - Orphaned objects remain in the database but are not discoverable
 - You can still retrieve them if you have the object ID: `operations.receive(obj_id=object_id)`
 - Always create a version after sending important data
@@ -467,8 +466,7 @@ print(wall.speckle_type)  # "MyCompany.Wall"
 ```
 
 <Warning>
-**Connector Compatibility**
-
+Connector Compatibility:
 Most Speckle connectors will **not recognize custom types** when receiving data into host applications. Your custom objects will likely be ignored during conversion to native application objects.
 
 **Best Practice:** Include a `displayValue` property with mesh geometry to ensure your custom objects are at least visible in the Speckle viewer and can be converted to generic native objects with geometry:

--- a/developers/sdks/python/concepts/proxification.mdx
+++ b/developers/sdks/python/concepts/proxification.mdx
@@ -42,7 +42,7 @@ A single wall might belong to:
 - Layer: "A-WALL"
 - Material: "Concrete"
 
-**Without proxification - you must choose ONE hierarchy:**
+Without proxification - you must choose ONE hierarchy:
 ```python
 # Option A: Nest by level (lose group info)
 level_1 = {
@@ -59,7 +59,7 @@ exterior_walls = {
 # OR just lose the organizational structure entirely
 ```
 
-**Problems:**
+Problems:
 - Can only have ONE primary hierarchy (level OR group OR layer)
 - Querying "exterior walls on Level 1" requires complex traversal
 - Can't represent that objects belong to multiple organizational systems
@@ -67,7 +67,7 @@ exterior_walls = {
 
 ### The Solution With Proxification
 
-**With proxification - MULTIPLE overlapping hierarchies:**
+With proxification - MULTIPLE overlapping hierarchies:
 ```python
 root = {
     # Objects stored once in flat/hierarchical elements
@@ -95,7 +95,7 @@ root = {
 }
 ```
 
-**Benefits:**
+Benefits:
 - Objects stored once, referenced by multiple organizational systems
 - Can query "exterior walls on Level 1" efficiently (intersection of two proxy lists)
 - Supports overlapping hierarchies (groups + layers + levels + materials)
@@ -636,14 +636,14 @@ for wall in walls:
 
 ### As a Data Consumer (Reading from Connectors)
 
-**You WILL encounter proxification when:**
+You WILL encounter proxification when:
 - Reading BIM/CAD data from Revit, Rhino, ArchiCAD, AutoCAD connectors
 - Working with organized models (levels, layers, groups, blocks)
 - Need to query by multiple criteria (e.g., "exterior walls on Level 1")
 - Analyzing material assignments across objects
 - Understanding instance/definition relationships
 
-**Resolution is required for:**
+Resolution is required for:
 - Finding objects by level, group, layer, or material
 - Querying intersections ("walls that are both exterior AND on Level 1")
 - Understanding which organizational systems an object belongs to
@@ -651,12 +651,12 @@ for wall in walls:
 
 ### As a Data Producer (Publishing with specklepy)
 
-**You typically DON'T need to create proxies when:**
+You typically DON'T need to create proxies when:
 - Publishing custom data with specklepy
 - Creating simple models
 - Working with small datasets
 
-**The SDK handles proxification automatically when:**
+The SDK handles proxification automatically when:
 - Sending large objects via `operations.send()`
 - Detachable properties are detected
 - Objects exceed chunking thresholds
@@ -699,7 +699,7 @@ def resolve_proxies(root):
     # Similar for other proxy types
 ```
 
-**See Also:**
+See Also:
 - `speckle-blender` repository for working implementations
 - Connector source code for practical proxy handling patterns
 
@@ -761,22 +761,19 @@ for wall in walls:
 
 ## Summary
 
-**Key Concepts:**
-
+Key Concepts:
 - **Proxification** = Storing objects separately and referencing by ID
 - **Proxy collections** live at root level with `@` prefix
 - **Resolution** requires two steps: build index, then resolve references
 - **All proxy types** follow the same resolution pattern
 
-**When to worry about proxification:**
-
+When to worry about proxification:
 - ✅ Reading BIM data from connectors (common)
 - ✅ Analyzing model organization (levels, groups, materials)
 - ✅ Working with large models
 - ❌ Publishing simple custom data (SDK handles it)
 
-**The Resolution Pattern:**
-
+The Resolution Pattern:
 1. Build applicationId index
 2. Get proxy collections from root
 3. Resolve applicationId strings to objects

--- a/developers/sdks/python/getting-started/authentication.mdx
+++ b/developers/sdks/python/getting-started/authentication.mdx
@@ -214,7 +214,7 @@ Choose the authentication method that best fits your use case:
 
 <Tabs>
   <Tab title="Development">
-    **Use environment variables or local accounts**
+    Use environment variables or local accounts:
 
     Store tokens in `.env` files (not committed to git) or use local account files.
 
@@ -230,7 +230,7 @@ Choose the authentication method that best fits your use case:
   </Tab>
 
   <Tab title="Production">
-    **Use environment variables**
+    Use environment variables:
 
     Store tokens in environment variables or secret managers (AWS Secrets Manager, Azure Key Vault, etc.).
 
@@ -241,7 +241,7 @@ Choose the authentication method that best fits your use case:
   </Tab>
 
   <Tab title="CI/CD">
-    **Use secrets management**
+    Use secrets management:
 
     Use GitHub Secrets, GitLab CI/CD variables, or similar.
 
@@ -253,7 +253,7 @@ Choose the authentication method that best fits your use case:
   </Tab>
 
   <Tab title="Multi-User Apps">
-    **Implement OAuth 2.0 flow**
+    Implement OAuth 2.0 flow:
 
     For web apps where users authenticate themselves. Each user gets their own token via OAuth.
   </Tab>
@@ -307,7 +307,7 @@ Follow the principle of least privilege - only grant the scopes your application
   <Accordion title="Invalid Token">
     **Error:** `403 Forbidden` or `Invalid token`
 
-    **Solution:**
+    Solution:
     - Verify the token is correct (no extra spaces)
     - Check the token hasn't been revoked
     - Ensure the token has the required scopes
@@ -317,7 +317,7 @@ Follow the principle of least privilege - only grant the scopes your application
   <Accordion title="Connection Refused">
     **Error:** `Connection refused` or `Failed to connect`
 
-    **Solution:**
+    Solution:
     - Verify the server URL is correct
     - Check your internet connection
     - For local servers, ensure the server is running
@@ -327,7 +327,7 @@ Follow the principle of least privilege - only grant the scopes your application
   <Accordion title="SSL Certificate Error">
     **Error:** `SSL: CERTIFICATE_VERIFY_FAILED`
 
-    **Solution:**
+    Solution:
     - For self-signed certificates, use `verify_certificate=False`
     - Install the certificate in your system's trust store
     - For production, use properly signed certificates
@@ -336,7 +336,7 @@ Follow the principle of least privilege - only grant the scopes your application
   <Accordion title="No Local Accounts Found">
     **Error:** `No default account found`
 
-    **Solution:**
+    Solution:
     - Use token authentication instead:
     ```python lines icon="python"
     token = os.environ.get("SPECKLE_TOKEN")
@@ -348,7 +348,7 @@ Follow the principle of least privilege - only grant the scopes your application
 ## Security Best Practices
 
 <Check>
-**Do:**
+Do:
 - Store tokens in environment variables
 - Use `.gitignore` to exclude `.env` files
 - Rotate tokens periodically
@@ -357,7 +357,7 @@ Follow the principle of least privilege - only grant the scopes your application
 </Check>
 
 <Warning>
-**Don't:**
+Don't:
 - Commit tokens to version control
 - Share tokens between team members
 - Use tokens in client-side code (use OAuth instead)

--- a/developers/sdks/python/getting-started/quickstart.mdx
+++ b/developers/sdks/python/getting-started/quickstart.mdx
@@ -227,8 +227,7 @@ print(f"Number of points: {len(received_data.points)}")
 
 
 <Info>
-**Why two steps?**
-
+Why two steps?:
 Versions store metadata (author, timestamp, message) separately from the actual
 object data. This keeps version lists fast and lightweight. You only download
 the full data when you explicitly `receive()` it.

--- a/developers/sdks/python/guides/bim-data-patterns.mdx
+++ b/developers/sdks/python/guides/bim-data-patterns.mdx
@@ -35,8 +35,7 @@ print(obj.properties.keys())  # Properties dictionary with BIM metadata
 
 ## Characteristics of BIM Data
 
-**Deep Nesting**
-
+Deep Nesting:
 BIM data often has nested structures with properties and sub-objects:
 
 ```python lines icon="python"
@@ -46,8 +45,7 @@ obj.properties["materials"]["Steel"]["area"]  # Nested material data
 #   └─1st level──┘  └──2nd level──┘  └─3rd─┘
 ```
 
-**Understanding v3 Object Types**
-
+Understanding v3 Object Types:
 In v3, there are **no typed BIM classes** like `Wall` or `Column`. Everything is a generic container:
 
 ```python lines icon="python"
@@ -64,8 +62,7 @@ print(obj.properties["family"])  # "Basic Wall"
 print(obj.properties["type"])  # "200mm"
 ```
 
-**Check properties, not types:**
-
+Check properties, not types:
 ```python lines icon="python"
 # Good - check properties for BIM semantics
 if obj.properties.get("category") == "Walls":
@@ -77,8 +74,7 @@ if "Wall" in obj.speckle_type:  # This won't match anything useful
     pass
 ```
 
-**Reference-Based Architecture**
-
+Reference-Based Architecture:
 Large nested objects are stored separately:
 
 ```python lines icon="python"
@@ -93,8 +89,7 @@ obj["@displayValue"]  # Returns: "hash123abc..."
 
 Revit objects have rich parameter collections organized by category.
 
-**Understanding Revit Parameter Structure**
-
+Understanding Revit Parameter Structure:
 ```python lines icon="python"
 # Typical Revit parameter structure
 {
@@ -132,8 +127,7 @@ Revit objects have rich parameter collections organized by category.
 }
 ```
 
-**Extracting Revit Parameters**
-
+Extracting Revit Parameters:
 ```python lines icon="python"
 from specklepy.objects import Base
 
@@ -197,8 +191,7 @@ for key, data in params.items():
     print(f"{key}: {value} {units}")
 ```
 
-**Filtering by Parameter Value**
-
+Filtering by Parameter Value:
 ```python lines icon="python"
 def filter_by_parameter(objects, param_name, param_value):
     """Find all objects with a specific parameter value."""
@@ -220,8 +213,7 @@ exterior_walls = filter_by_parameter(walls, "Function", "Exterior")
 print(f"Found {len(exterior_walls)} exterior walls")
 ```
 
-**Converting Parameters to DataFrame**
-
+Converting Parameters to DataFrame:
 ```python lines icon="python"
 import pandas as pd
 
@@ -286,8 +278,7 @@ Display geometry is often detached for performance.
 **Proxified Display Values:** In many BIM models, display values are stored as **instance references** that need to be resolved using applicationId lookups. When `displayValue` contains references instead of direct meshes, see [Extracting Display Values and Transform Instances](/developers/sdks/python/guides/working-with-proxies) for the complete workflow on building applicationId indexes and resolving these references.
 </Note>
 
-**Understanding Display Values**
-
+Understanding Display Values:
 BIM objects (like `DataObject`) have a `displayValue` property containing visualization geometry as a list of `Mesh` objects or other geometry.
 
 <Info>
@@ -312,8 +303,7 @@ if hasattr(wall, "displayValue"):
             print(f"  - {mesh.vertices_count} vertices")
 ```
 
-**Extracting All Display Geometry**
-
+Extracting All Display Geometry:
 ```python lines icon="python"
 from specklepy.objects.geometry import Mesh
 
@@ -353,8 +343,7 @@ total_vertices = sum(m.vertices_count for m in all_meshes)
 print(f"Total display geometry: {len(all_meshes)} meshes, {total_vertices} vertices")
 ```
 
-**Finding Atomic Displayable Objects**
-
+Finding Atomic Displayable Objects:
 Extract all objects with `displayValue` - these are the atomic, viewer-selectable BIM elements:
 
 ```python lines icon="python"
@@ -413,8 +402,7 @@ for category, count in sorted(by_category.items()):
     print(f"  {category}: {count}")
 ```
 
-**Computing Bounding Box from Display**
-
+Computing Bounding Box from Display:
 ```python lines icon="python"
 from specklepy.objects.geometry import Point
 
@@ -463,8 +451,7 @@ print(f"Center: ({bbox['center'].x}, {bbox['center'].y}, {bbox['center'].z})")
 
 Rhino objects may include native binary data for Rhino-to-Rhino workflows.
 
-**Understanding EncodedValue**
-
+Understanding EncodedValue:
 ```python lines icon="python"
 # Rhino extrusion with encodedValue
 {
@@ -474,8 +461,7 @@ Rhino objects may include native binary data for Rhino-to-Rhino workflows.
 }
 ```
 
-**Checking for EncodedValue**
-
+Checking for EncodedValue:
 ```python lines icon="python"
 def has_native_rhino_data(obj):
     """Check if object has Rhino native data."""
@@ -524,8 +510,7 @@ Complex models use instance/definition patterns for efficiency (like Revit famil
 **Instance Definitions Location:** Instance definitions are stored in the `instanceDefinitionProxies` collection on the root object, not nested in the hierarchy. You need to build an applicationId index to resolve instance references, similar to how level proxies work (see Pattern 5).
 </Note>
 
-**Understanding Instances**
-
+Understanding Instances:
 Instance objects reference their definition by `applicationId`:
 
 ```python lines icon="python"
@@ -548,8 +533,7 @@ root.instanceDefinitionProxies = [
 }
 ```
 
-**Extracting Instances and Definitions**
-
+Extracting Instances and Definitions:
 ```python lines icon="python"
 def extract_instance_definitions(root):
     """Extract instance definitions from instanceDefinitionProxies."""
@@ -622,8 +606,7 @@ This models real-world CAD/BIM organization where groups, layers, levels, and bl
 </Note>
 
 <Info>
-**The Proxy Pattern Workflow:**
-
+The Proxy Pattern Workflow:
 1. **Proxies live at root level** - Look for `levelProxies`, `colorProxies`, etc. on the root object
 2. **Proxies contain applicationId lists** - Each proxy has an `objects` array of applicationId strings
 3. **Build an applicationId index** - Map applicationIds to actual objects in the `elements[]` hierarchy
@@ -633,8 +616,7 @@ This models real-world CAD/BIM organization where groups, layers, levels, and bl
 This is a **two-step lookup process**, not direct nesting!
 </Info>
 
-**Understanding Proxy Collections**
-
+Understanding Proxy Collections:
 Proxy collections are stored as **properties at the root object level**:
 
 - `levelProxies` - Building levels/storeys organization
@@ -645,8 +627,7 @@ Proxy collections are stored as **properties at the root object level**:
 
 **Key Concept:** These are **reference collections**, not nested hierarchies. They contain lists of `applicationId` strings that point to objects in the `elements[]` hierarchy.
 
-**LevelProxy Structure**
-
+LevelProxy Structure:
 ```python lines icon="python"
 from specklepy.objects.proxies import LevelProxy
 
@@ -669,8 +650,7 @@ for level_proxy in level_proxies:
     print(level_proxy.applicationId)  # "level-guid"
 ```
 
-**Finding LevelProxy Collections at Root**
-
+Finding LevelProxy Collections at Root:
 ```python lines icon="python"
 from specklepy.objects.proxies import LevelProxy
 
@@ -700,8 +680,7 @@ for level in level_proxies:
     print(f"{level_name}: {object_count} objects at {elevation}m")
 ```
 
-**Resolving Objects by applicationId**
-
+Resolving Objects by applicationId:
 The challenge: LevelProxy contains `applicationId` strings, but you need to find the actual objects in the `elements[]` hierarchy.
 
 ```python lines icon="python"
@@ -751,8 +730,7 @@ if app_id in app_id_index:
     print(f"Found: {obj.name}")
 ```
 
-**Grouping Objects by Level**
-
+Grouping Objects by Level:
 Combine proxy collections with applicationId index to organize objects:
 
 ```python lines icon="python"
@@ -801,8 +779,7 @@ for level_name, objects in levels.items():
         print(f"  {category}: {count}")
 ```
 
-**Complete Proxy Pattern Helper**
-
+Complete Proxy Pattern Helper:
 A comprehensive helper for working with all proxy types:
 
 ```python lines icon="python"
@@ -865,8 +842,7 @@ for level_proxy in proxies["levels"]:
     print(f"  {level_name}: {len(level_proxy.objects)} objects")
 ```
 
-**Finding an Object's Level**
-
+Finding an Object's Level:
 To find which level an object belongs to, you need to **reverse lookup** from the proxy collections:
 
 ```python lines icon="python"
@@ -900,8 +876,7 @@ print(f"Wall is on: {level_name}")
 
 Revit objects can contain detailed material quantity takeoffs stored in `properties["Material Quantities"]`. These quantities exist **only on individual objects** - there is no pre-aggregated total at the model level. To get project-wide material totals, you need to traverse all objects and aggregate their material quantities.
 
-**Understanding Material Quantities**
-
+Understanding Material Quantities:
 Each object with materials contains a `Material Quantities` dictionary with material breakdowns:
 
 ```python lines icon="python"
@@ -935,8 +910,7 @@ obj.properties["Material Quantities"] = {
 }
 ```
 
-**Extracting Material Quantities from Individual Objects**
-
+Extracting Material Quantities from Individual Objects:
 ```python lines icon="python"
 def extract_material_quantities(obj):
     """Extract material quantities from a single object's properties."""
@@ -956,8 +930,7 @@ for material_name, mat_data in mat_quantities.items():
     print(f"  {material_name}: {volume} {units}")
 ```
 
-**Aggregating Model-Wide Material Totals**
-
+Aggregating Model-Wide Material Totals:
 To get total material quantities across the entire model version, traverse all objects and aggregate:
 
 ```python lines icon="python"
@@ -1032,8 +1005,7 @@ for material, data in sorted(materials.items()):
         print(f"  Estimated Weight: {weight:.2f} kg")
 ```
 
-**Converting to DataFrame for Analysis**
-
+Converting to DataFrame for Analysis:
 ```python lines icon="python"
 import pandas as pd
 

--- a/developers/sdks/python/guides/how-to-find-and-extract-data.mdx
+++ b/developers/sdks/python/guides/how-to-find-and-extract-data.mdx
@@ -81,7 +81,7 @@ The SDK provides three key components for traversal:
    - `_members_to_traverse` - What properties to traverse? (function returning list)
    - `_should_return_to_output` - Include objects in results? (boolean)
 
-**In the examples below, look for comments showing where each component is used.**
+In the examples below, look for comments showing where each component is used.:
 </Accordion>
 
 ```python lines icon="python"
@@ -100,8 +100,7 @@ for context in traversal.traverse(root):
     print(f"Visiting: {name}")
 ```
 
-**Understanding the traversal flow:**
-
+Understanding the traversal flow:
 ```python lines icon="python"
 # Visual Flow:
 #
@@ -117,15 +116,14 @@ for context in traversal.traverse(root):
 #       context.member_name ←  Access property name (optional)
 ```
 
-**Why use GraphTraversal?**
+Why use GraphTraversal?:
 - ✅ Handles all edge cases (dicts, lists, nested Base objects)
 - ✅ Provides context (parent object, property name)
 - ✅ Supports custom rules for filtering during traversal
 - ✅ Memory efficient (uses iterators, not lists)
 - ✅ Battle-tested in production SDK code
 
-**The traversal pattern has three parts:**
-
+The traversal pattern has three parts:
 1. **Base case:** Check if object is a `Base` instance
 2. **Process:** Do something with the current object
 3. **Recurse:** Visit all child objects via `get_member_names()`
@@ -141,8 +139,7 @@ for name in obj.get_member_names():
     # Value is always a data property, never a method
 ```
 
-**Collecting objects during traversal using GraphTraversal:**
-
+Collecting objects during traversal using GraphTraversal:
 Instead of just visiting objects, you often want to collect them
 into a list. Here are two approaches - collecting all at once or
 processing as you go:
@@ -169,8 +166,7 @@ for context in traversal.traverse(root):
             print(f"Found {category}: {obj_name}")
 ```
 
-**Understanding TraversalContext:**
-
+Understanding TraversalContext:
 Each context provides information about where you are in the
 object tree - the current object, what property it came from,
 and its parent:
@@ -191,8 +187,7 @@ for context in traversal.traverse(root):
         print(f"{obj.name} is in {parent_obj.name}.{prop_name}")
 ```
 
-**Using TraversalRule to control traversal:**
-
+Using TraversalRule to control traversal:
 Rules give you fine-grained control over what gets traversed
 and returned. They're useful when you want to skip certain
 properties or limit results during traversal:
@@ -229,8 +224,7 @@ for context in traversal.traverse(root):
     # displayValue won't be traversed due to our rule
 ```
 
-**Simpler approach - filter after traversal:**
-
+Simpler approach - filter after traversal:
 If you just need to skip certain objects, filtering after
 traversal is often clearer than writing a custom rule:
 
@@ -248,8 +242,7 @@ for context in traversal.traverse(root):
     print(f"Visiting: {getattr(obj, 'name', 'unnamed')}")
 ```
 
-**Comprehensive example - all three components together:**
-
+Comprehensive example - all three components together:
 ```python lines icon="python" expandable
 from specklepy.objects.graph_traversal.traversal import (
     GraphTraversal,
@@ -386,8 +379,7 @@ See [BIM Data Patterns](/developers/sdks/python/guides/bim-data-patterns)
 for production patterns.
 </Note>
 
-**Multiple filter criteria:**
-
+Multiple filter criteria:
 When you need to match objects on several properties at once
 (e.g., walls that are also concrete), pass multiple key-value
 pairs to check all conditions:
@@ -432,8 +424,7 @@ concrete_walls = find_by_properties(
 )
 ```
 
-**Using custom filter functions:**
-
+Using custom filter functions:
 For complex filtering logic (numeric comparisons, nested
 properties, combined conditions), pass a custom function
 that returns `True` for objects you want to keep:
@@ -516,8 +507,7 @@ meshes = extract_display_meshes(root)
 print(f"Found {len(meshes)} meshes")
 ```
 
-**Extracting geometry with metadata:**
-
+Extracting geometry with metadata:
 Often you need to know which object each mesh came from.
 Use TraversalContext to track source objects and their
 properties:
@@ -579,8 +569,7 @@ for item in mesh_data:
     print(f"  Vertices: {vert_count}")
 ```
 
-**Handling different geometry types:**
-
+Handling different geometry types:
 Not all geometry is meshes - you might also encounter
 points, lines, and polylines. Check for all geometry types
 you're interested in:
@@ -705,8 +694,7 @@ Building A (Buildings)
   Level 2 (Levels)
 ```
 
-**Collecting objects by level:**
-
+Collecting objects by level:
 To analyze your data by depth in the tree (e.g., root
 objects vs. deeply nested objects), organize objects by
 their hierarchy level:
@@ -746,8 +734,7 @@ for level, objects in sorted(by_level.items()):
     print(f"Level {level}: {len(objects)} objects")
 ```
 
-**Flattening vs. preserving hierarchy:**
-
+Flattening vs. preserving hierarchy:
 Choose between flattening (all objects in one list) or
 preserving structure (nested dictionaries). Flatten when
 you just need to process objects; preserve when hierarchy
@@ -1007,16 +994,16 @@ report = generate_category_report(root)
 
 ## Learn More
 
-**Core Concepts:**
+Core Concepts:
 - [Data Traversal](/developers/sdks/python/concepts/data-traversal) - Deep dive into traversal patterns
 - [Display Values](/developers/sdks/python/concepts/display-values) - Understanding geometry representation
 
-**Guides:**
+Guides:
 - [BIM Data Patterns](/developers/sdks/python/guides/bim-data-patterns) - Advanced BIM-specific patterns
 - [Working with Geometry](/developers/sdks/python/guides/working-with-geometry) - Geometry manipulation
 - [Understanding Speckle Mesh](/developers/sdks/python/guides/understanding-speckle-mesh) - Mesh structure details
 
-**Next Steps:**
+Next Steps:
 - [Advanced: Performance and Complex Patterns](/developers/sdks/python/guides/how-to-optimize-and-handle-complexity) - Learn optimization techniques
 
 ## Next Steps

--- a/developers/sdks/python/guides/how-to-optimize-and-handle-complexity.mdx
+++ b/developers/sdks/python/guides/how-to-optimize-and-handle-complexity.mdx
@@ -37,8 +37,7 @@ floors = find_by_category(root, "Floors")    # Traverse 2
 columns = find_by_category(root, "Columns")  # Traverse 3
 ```
 
-**Build an index once, then perform fast lookups using GraphTraversal:**
-
+Build an index once, then perform fast lookups using GraphTraversal:
 ```python lines icon="python" expandable
 from specklepy.objects.graph_traversal.traversal import GraphTraversal
 
@@ -74,8 +73,7 @@ print(f"Columns: {len(columns)}")
 
 **Indexing pattern:** (1) **Traverse once** - Visit every object in the tree, (2) **Extract key** - Get the property value to index by (e.g., category), (3) **Store reference** - Add object to a dictionary by that key, (4) **Fast lookup** - Use dictionary access (O(1)) instead of tree traversal (O(n)).
 
-**Performance comparison:**
-
+Performance comparison:
 ```python lines icon="python"
 # Without index (repeated traversal)
 # Time: O(n * m) where n = objects, m = searches
@@ -209,7 +207,7 @@ columns = index.get("Columns", [])
 
 You need to decide whether to traverse directly or build an index first. The wrong choice can hurt performance.
 
-**Use direct traversal when:**
+Use direct traversal when:
 - ✅ Single search on a dataset
 - ✅ Small datasets (less than 100 objects)
 - ✅ One-time operation
@@ -230,7 +228,7 @@ def find_specific_wall(root, wall_name):
 wall = find_specific_wall(root, "W-101")
 ```
 
-**Use indexes when:**
+Use indexes when:
 - ✅ Multiple searches on the same dataset
 - ✅ Large datasets (1000+ objects)
 - ✅ Repeated lookups by the same property
@@ -261,8 +259,7 @@ def analyze_by_category(root):
     }
 ```
 
-**Performance example:**
-
+Performance example:
 ```python lines icon="python" expandable
 import time
 
@@ -295,8 +292,7 @@ print(f"Speedup: {direct_time / indexed_time:.1f}x faster")
 
 Some objects in Speckle are "detached" - stored separately and referenced by ID. You see properties like `@displayValue` instead of the actual object.
 
-**Understand when and why detachment happens:**
-
+Understand when and why detachment happens:
 ```python lines icon="python"
 from specklepy.objects import Base
 
@@ -320,8 +316,7 @@ if is_detached(obj, "displayValue"):
 
 **Why detachment happens:** (1) **Performance** - Large objects (big meshes) are stored separately, (2) **Deduplication** - Same object can be referenced multiple times, (3) **Lazy loading** - Objects loaded only when needed.
 
-**How it's resolved:**
-
+How it's resolved:
 ```python lines icon="python"
 from specklepy.api import operations
 from specklepy.transports.server import ServerTransport
@@ -339,8 +334,7 @@ if hasattr(obj, "displayValue"):
     print(f"Vertices: {len(mesh.vertices)}")
 ```
 
-**Checking for detached properties:**
-
+Checking for detached properties:
 ```python lines icon="python" expandable
 def find_detached_properties(obj):
     """Find all detached properties on an object."""
@@ -424,8 +418,7 @@ print(f"Structural: {structural}")
 print(f"Comments: {comments}")
 ```
 
-**Understanding Revit parameter structure:**
-
+Understanding Revit parameter structure:
 ```python lines icon="python"
 # Revit parameters are nested like this:
 obj.properties = {
@@ -446,8 +439,7 @@ obj.properties = {
 }
 ```
 
-**Extracting all parameters:**
-
+Extracting all parameters:
 ```python lines icon="python" expandable
 def get_all_parameters(obj):
     """Extract all parameters as flat dictionary."""
@@ -487,8 +479,7 @@ for name, data in params.items():
     print(f"{name}: {value} {units or ''}")
 ```
 
-**Building a parameter index using GraphTraversal:**
-
+Building a parameter index using GraphTraversal:
 ```python lines icon="python" expandable
 from specklepy.objects.graph_traversal.traversal import GraphTraversal
 
@@ -690,15 +681,15 @@ print(df[df["structural"] == True].groupby("category").size())
 
 ## Learn More
 
-**Core Concepts:**
+Core Concepts:
 - [Data Traversal](/developers/sdks/python/concepts/data-traversal) - Traversal fundamentals
 - [Objects & Base Class](/developers/sdks/python/concepts/objects) - Deep dive into object system
 
-**Guides:**
+Guides:
 - [BIM Data Patterns](/developers/sdks/python/guides/bim-data-patterns) - Advanced BIM patterns
 - [Intermediate: Finding and Extracting Data](/developers/sdks/python/guides/how-to-find-and-extract-data) - Traversal and filtering
 
-**API Reference:**
+API Reference:
 - [Operations](/developers/sdks/python/api-reference/operations) - Send/receive operations
 - [Transports](/developers/sdks/python/api-reference/transports) - Data transport layer
 

--- a/developers/sdks/python/guides/how-to-work-with-objects.mdx
+++ b/developers/sdks/python/guides/how-to-work-with-objects.mdx
@@ -46,7 +46,7 @@ print(f"Created: {obj.name}")
 
 `Base` objects are Python classes that accept any property name dynamically (no predefined schema needed), serialize automatically for Speckle, support nesting (objects within objects), and work with Python's native attribute access.
 
-**When to create Base objects:**
+When to create Base objects:
 - Building custom data structures (surveys, analysis results, schedules)
 - Grouping related objects together
 - Adding application-specific metadata
@@ -67,8 +67,7 @@ obj.elementId = "custom-123"
 
 You need to attach metadata to objects, but you're unsure whether to use direct attributes (`obj.name`) or the properties dictionary (`obj.properties["name"]`).
 
-**Use direct attributes for structure and organization:**
-
+Use direct attributes for structure and organization:
 ```python lines icon="python"
 from specklepy.objects import Base
 
@@ -87,8 +86,7 @@ level.elements = []  # Objects on this level
 building.levels.append(level)
 ```
 
-**Use the properties dictionary for queryable metadata:**
-
+Use the properties dictionary for queryable metadata:
 ```python lines icon="python"
 from specklepy.objects import Base
 
@@ -119,8 +117,7 @@ thickness = wall.properties.get("thickness", 0)
 **Which to use?** Both are valid Speckle patterns! The `properties` dictionary is a *convention* that makes metadata more discoverable. If Revit sends a wall, its category will be in `properties["category"]` - following this pattern makes your data easier to work with across platforms.
 </Info>
 
-**Combining both approaches:**
-
+Combining both approaches:
 ```python lines icon="python"
 from specklepy.objects import Base
 from specklepy.objects.geometry import Point, Mesh
@@ -149,8 +146,7 @@ beam.properties = {
 
 You have a Speckle object and need to read its properties, but you don't know what properties it has or how to access them safely.
 
-**For direct attributes:**
-
+For direct attributes:
 ```python lines icon="python"
 # Direct access (if you know the property exists)
 name = obj.name
@@ -167,8 +163,7 @@ name = getattr(obj, "name", "Unnamed")
 height = getattr(obj, "height", 0.0)
 ```
 
-**For properties dictionary:**
-
+For properties dictionary:
 ```python lines icon="python"
 # Direct access (might raise KeyError)
 category = obj.properties["category"]  # KeyError if missing!
@@ -218,8 +213,7 @@ for name in obj.get_member_names():
 ```
 </Accordion>
 
-**Safe property access pattern:**
-
+Safe property access pattern:
 ```python lines icon="python" expandable
 def safely_read_object(obj):
     """Read all properties from an object safely."""
@@ -265,8 +259,7 @@ name = getattr(obj, "name", "Unnamed")
 
 You need to work with multiple objects - filtering them, counting them, or processing them in bulk.
 
-**Looping through lists:**
-
+Looping through lists:
 ```python lines icon="python"
 from specklepy.objects import Base
 
@@ -287,8 +280,7 @@ for element in building.elements:
     print(f"{name}: {category}")
 ```
 
-**Filtering lists:**
-
+Filtering lists:
 ```python lines icon="python"
 # Filter with list comprehension
 walls = [
@@ -306,8 +298,7 @@ load_bearing_walls = [
 ]
 ```
 
-**Counting and aggregating:**
-
+Counting and aggregating:
 ```python lines icon="python"
 # Count by category
 from collections import Counter
@@ -366,8 +357,7 @@ for level in building.elements:
     print(f"{level_name}: {room_count} rooms")
 ```
 
-**Common collection patterns:**
-
+Common collection patterns:
 ```python lines icon="python"
 # Check if object has elements
 if hasattr(obj, "elements") and obj.elements:
@@ -392,8 +382,7 @@ wall = find_first(building.elements, "Walls")
 ```
 
 <Warning>
-**Check if elements exists before looping:**
-
+Check if elements exists before looping:
 ```python
 # ❌ Bad - crashes if no elements property
 for element in obj.elements:
@@ -553,15 +542,15 @@ for level in building.elements:
 
 ## Learn More
 
-**Core Concepts:**
+Core Concepts:
 - [Objects & Base Class](/developers/sdks/python/concepts/objects) - Deep dive into Base and object system
 - [Data Types](/developers/sdks/python/concepts/data-types) - Understanding Speckle's type system
 
-**Guides:**
+Guides:
 - [Simple Data Patterns](/developers/sdks/python/guides/simple-data-patterns) - More examples of custom data structures
 - [Intermediate: Finding and Extracting Data](/developers/sdks/python/guides/how-to-find-and-extract-data) - Learn to traverse and filter nested structures
 
-**API Reference:**
+API Reference:
 - [Base class methods](/developers/sdks/python/api-reference/operations) - Complete Base API documentation
 
 ## Next Steps

--- a/developers/sdks/python/guides/simple-data-patterns.mdx
+++ b/developers/sdks/python/guides/simple-data-patterns.mdx
@@ -155,8 +155,7 @@ Properties can be any type (string, number, bool, list). Always use `.get()` wit
 </Warning>
 
 <Info>
-**Properties Dictionary vs. Direct Attributes:**
-
+Properties Dictionary vs. Direct Attributes:
 Use the `properties` dictionary when:
 - Creating data that needs to be queryable by other applications
 - Working with metadata that follows BIM/connector conventions

--- a/developers/sdks/python/guides/understanding-speckle-mesh.mdx
+++ b/developers/sdks/python/guides/understanding-speckle-mesh.mdx
@@ -53,7 +53,7 @@ vertices = [
 vertex_count = len(vertices) // 3  # = 4
 ```
 
-**Key points:**
+Key points:
 - Always a multiple of 3 (X, Y, Z)
 - Indexed starting from 0
 - Units apply to these coordinates
@@ -73,7 +73,7 @@ The `faces` array encodes face information as:
 └── size ─┘└────── indices ─────┘└─ next face... ──────────┘
 ```
 
-**Structure:**
+Structure:
 - First number = how many vertices in this face
 - Next N numbers = vertex indices for this face
 - Then repeat for next face
@@ -149,13 +149,13 @@ faces = [
 
 Most mesh libraries only support triangles (or triangles + quads). Speckle supports **nGons** - faces with any number of vertices.
 
-**Advantages:**
+Advantages:
 - **Preserves design intent** - Doesn't force triangulation
 - **BIM compatibility** - Revit, Rhino often use quads and nGons
 - **Round-trip fidelity** - Original face structure preserved
 - **Smaller data** - No unnecessary triangulation
 
-**Trade-off:**
+Trade-off:
 - More complex to parse
 - Rendering engines must triangulate
 
@@ -291,7 +291,7 @@ mesh = Mesh(
 )
 ```
 
-**Important:**
+Important:
 - Length of `colors` must equal number of vertices
 - Colors interpolate across faces (gradient effect)
 - If empty, viewer uses default material color
@@ -338,7 +338,7 @@ material = RenderMaterial(
 )
 ```
 
-**Properties:**
+Properties:
 - `name` (str, required): Material name
 - `diffuse` (int, required): Base color as ARGB integer (see [Vertex Colors](#vertex-colors))
 - `opacity` (float): Transparency level (default: 1.0)
@@ -374,13 +374,13 @@ For efficiently sharing materials across multiple objects in a collection, use `
 
 ### Material vs Vertex Colors
 
-**Use RenderMaterial when:**
+Use RenderMaterial when:
 - Applying consistent appearance to entire objects
 - Using physically-based properties (metalness, roughness)
 - Need transparency or emissive effects
 - Sharing materials across multiple objects
 
-**Use vertex colors when:**
+Use vertex colors when:
 - Per-vertex color variation (gradients, heatmaps)
 - Visualizing analysis data
 - Color-coding mesh regions
@@ -408,7 +408,7 @@ mesh = Mesh(
 )
 ```
 
-**Important facts:**
+Important facts:
 - Length of `vertexNormals` must be same as `vertices` (3x vertex count)
 - Normals should be unit vectors (length = 1)
 - If empty, viewer auto-calculates normals
@@ -421,7 +421,7 @@ mesh = Mesh(
 **Speckle connectors produce meshes with all hard-edged faces by default** - meaning every face has its own duplicated vertices rather than sharing vertices between faces. This approach prioritizes conversion speed and ensures consistent rendering.
 </Info>
 
-**Understanding edge behavior:**
+Understanding edge behavior:
 - **Hard edges** are the default - each face has its own vertices, creating sharp transitions
 - **Soft edges** would require shared vertices with averaged normals, but connectors don't typically create these
 - This means most Speckle meshes have "flat" shading rather than smooth shading
@@ -436,7 +436,7 @@ If smooth shading or mixed hard/soft edges are required for your use case, mesh 
 **Speckle doesn't have a "two-sided" material flag.** Faces have a front and back determined by winding order, but both sides render the same in the viewer.
 </Info>
 
-**Winding order:**
+Winding order:
 - Right-hand rule determines front face
 - Counter-clockwise = front (when viewed from front)
 - Most viewers render both sides regardless
@@ -702,8 +702,7 @@ def print_mesh_info(mesh):
 
 ## Summary
 
-**Key takeaways:**
-
+Key takeaways:
 1. **Vertices** = Flat list `[x,y,z, x,y,z, ...]`
 2. **Faces** = Packed format `[count, i1, i2, i3, count, ...]`
 3. **nGons supported** = Any number of vertices per face
@@ -714,8 +713,7 @@ def print_mesh_info(mesh):
 8. **No two-sided flag** = Must duplicate faces with reversed winding
 9. **Always specify units**
 
-**Common gotchas:**
-
+Common gotchas:
 - ❌ Don't forget the vertex count in faces array
 - ❌ Colors/normals must match vertex count
 - ❌ Connectors create flat shading by default (no shared vertices)

--- a/developers/sdks/python/guides/working-with-proxies.mdx
+++ b/developers/sdks/python/guides/working-with-proxies.mdx
@@ -7,7 +7,7 @@ description: Learn how to extract geometry from display values and resolve insta
 
 When working with BIM models in Speckle, you'll encounter objects whose geometry is represented through `displayValue` properties. This guide shows you how to extract this geometry, including how to handle **instance definitions** that require resolving `applicationId` references.
 
-**What you'll learn:**
+What you'll learn:
 - How to extract meshes from `displayValue` properties
 - How to build an applicationId index for reference lookups
 - How to resolve InstanceDefinition references to get actual geometry
@@ -619,19 +619,19 @@ for item in obj.displayValue:
 
 ## Summary
 
-**Key concepts:**
+Key concepts:
 - ✅ **displayValue** can contain direct meshes or instance references
 - ✅ **InstanceDefinition** objects reference geometry by `applicationId`, not direct embedding
 - ✅ **applicationId index** enables fast lookups when resolving references
 - ✅ **Transformations** position, rotate, and scale instanced geometry
 
-**Core workflow:**
+Core workflow:
 1. Build applicationId index once
 2. Extract instance definitions, resolving their geometry references
 3. Process displayValue, handling both direct meshes and instance references
 4. Apply transformations where present
 
-**For more on proxies:**
+For more on proxies:
 - [BIM Data Patterns: Pattern 5](/developers/sdks/python/guides/bim-data-patterns#pattern-5-level-and-location-data-with-proxy-collections)
 - [Proxification Concepts](/developers/sdks/python/concepts/proxification)
 

--- a/developers/server/architecture.mdx
+++ b/developers/server/architecture.mdx
@@ -18,7 +18,7 @@ The Speckle server follows a microservices architecture pattern, with each compo
 
 The central component that handles all client requests and business logic.
 
-**Responsibilities:**
+Responsibilities:
 - Authentication & Authorization
 - Project Management
 - Data Operations
@@ -29,7 +29,7 @@ The central component that handles all client requests and business logic.
 
 The web interface for managing Speckle projects and data.
 
-**Responsibilities:**
+Responsibilities:
 - User Interface
 - Data Visualization
 - User Management
@@ -56,7 +56,7 @@ Object storage handles the actual 3D data and file assets. We require an S3-comp
 
 The cache layer provides caching and session management capabilities, serving as the Redis-compatible open-source alternative.
 
-**Cached Data:**
+Cached Data:
 - User Sessions
 - Rate Limiting
 - Messages between supporting services and the API server

--- a/developers/server/deployment-options.mdx
+++ b/developers/server/deployment-options.mdx
@@ -26,31 +26,27 @@ Speckle server can be deployed using several different methods, each suited for 
 
 **Best For:** Small to medium teams, organizations starting with Speckle, cost-conscious deployments
 
-**Key Benefits:**
-
+Key Benefits:
 - **Simple Setup**: Single command deployment with minimal configuration
 - **Cost Effective**: Runs on any Linux server with Docker support
 - **Full Control**: Complete control over infrastructure and configuration
 - **Easy Maintenance**: Simple update and backup procedures
 - **Production Ready**: Includes SSL, monitoring, and backup capabilities
 
-**Technical Requirements:**
-
+Technical Requirements:
 - Docker and Docker Compose installed
 - Linux server with 4GB+ RAM and 20GB+ storage
 - Domain name and SSL certificate
 - Basic Linux administration knowledge
 
-**Use Cases:**
-
+Use Cases:
 - Teams of 5-50 users
 - Organizations wanting full control over their data
 - Cost-sensitive deployments
 - Proof of concept and testing environments
 - Educational institutions and research organizations
 
-**Limitations:**
-
+Limitations:
 - Single server deployment (no built-in high availability)
 - Manual scaling required
 - Limited to single geographic location
@@ -60,32 +56,28 @@ Speckle server can be deployed using several different methods, each suited for 
 
 **Best For:** Large organizations, enterprise deployments, high-availability requirements
 
-**Key Benefits:**
-
+Key Benefits:
 - **High Availability**: Multi-node deployment with automatic failover
 - **Auto Scaling**: Automatic scaling based on load and resource usage
 - **Global Deployment**: Multi-region and multi-cloud deployments
 - **Advanced Orchestration**: Rolling updates, health checks, and auto-recovery
 - **Enterprise Features**: Load balancing, ingress management, and monitoring
 
-**Technical Requirements:**
-
+Technical Requirements:
 - Kubernetes cluster (v1.33+) with at least 3 nodes
 - kubectl and Helm package manager
 - Gateway API enabled Kubernetes cluster or service mesh
 - Domain name and SSL certificates
 - Kubernetes administration expertise
 
-**Use Cases:**
-
+Use Cases:
 - Enterprise organizations with 50+ users
 - High-availability production environments
 - Multi-region deployments
 - Organizations with existing Kubernetes infrastructure
 - Applications requiring advanced orchestration
 
-**Limitations:**
-
+Limitations:
 - High complexity and learning curve
 - Requires significant infrastructure resources
 - Expensive for small deployments
@@ -110,8 +102,7 @@ Speckle server can be deployed using several different methods, each suited for 
 
 ### I want to get started quickly with minimal setup
 
-**Choose: Docker Compose**
-
+Choose: Docker Compose:
 - Simple one-command deployment
 - Minimal configuration required
 - Works on any Linux server
@@ -119,8 +110,7 @@ Speckle server can be deployed using several different methods, each suited for 
 
 ### I'm deploying for my organization and need reliability
 
-**Choose: Docker Compose**
-
+Choose: Docker Compose:
 - Production-ready with SSL and monitoring
 - Cost-effective for most organizations
 - Easy to maintain and update
@@ -128,8 +118,7 @@ Speckle server can be deployed using several different methods, each suited for 
 
 ### I need enterprise-grade deployment with high availability
 
-**Choose: Kubernetes**
-
+Choose: Kubernetes:
 - Multi-node deployment with automatic failover
 - Auto-scaling capabilities
 - Advanced monitoring and orchestration
@@ -137,8 +126,7 @@ Speckle server can be deployed using several different methods, each suited for 
 
 ### I need global deployment across multiple regions
 
-**Choose: Kubernetes**
-
+Choose: Kubernetes:
 - Multi-region deployment capabilities
 - Load balancing across geographic locations
 - Advanced networking and routing

--- a/developers/server/self-hosted-vs-cloud-hosted-speckle.mdx
+++ b/developers/server/self-hosted-vs-cloud-hosted-speckle.mdx
@@ -61,8 +61,7 @@ Typical patterns:
 
 In practice, **cost and capacity** on hosted plans scale most with **model versions, data churn, and how often you sync and automate** (together with model size and concurrency)—not primarily “per API call” for building custom apps.
 
-**Bottlenecks:**
-
+Bottlenecks:
 - **Hosted:** governed by workspace plan limits and fair-use expectations described with your plan.
 - **Self-hosted:** governed entirely by **your** infrastructure—especially database performance, object storage, and throughput for background processing.
 

--- a/developers/viewer/acceleration-structure-api.mdx
+++ b/developers/viewer/acceleration-structure-api.mdx
@@ -24,8 +24,7 @@ constructor(bvh: MeshBVH)
 
 Populates/constructs this acceleration structure with the backing BVH.
 
-**Parameters**
-
+Parameters:
 - **bvh**: The backing BVH as a [_MeshBVH_](https://github.com/gkjohnson/three-mesh-bvh/blob/master/src/core/MeshBVH.js)
 
 ## Accessors
@@ -70,8 +69,7 @@ static buildBVH(
 
 Build a BVH using the provided geometry data.
 
-**Parameters**
-
+Parameters:
 - **indices**: Geometry indices
 - **position**: Geometry vertex positions
 - **options**: [_BVHOptions_](/developers/viewer/acceleration-structure-api#bvhoptions)
@@ -87,8 +85,7 @@ getBoundingBox(target?: Box3): Box3
 
 Gets the aabb of the entire BVH.
 
-**Parameters**
-
+Parameters:
 - _optional_ **target**: [_Box3_](https://threejs.org/docs/index.html?q=box3#api/en/math/Box3)
 
 **Returns**: [_Box3_](https://threejs.org/docs/index.html?q=box3#api/en/math/Box3)
@@ -101,8 +98,7 @@ getVertexAtIndex(index: number): Vector3
 
 Gets position value of a vertex at the given index inside the BVH vertex position array.
 
-**Parameters**
-
+Parameters:
 - **index**: number
 
 **Returns**: [_Vector3_](https://threejs.org/docs/index.html?q=vec#api/en/math/Vector3)
@@ -118,8 +114,7 @@ raycast(
 
 Wrapper over three-mesh-bvh raycast function. Keeps original behavior,but makes sure input and output spaces are correct.
 
-**Parameters**
-
+Parameters:
 - **ray**: [_Ray_](https://threejs.org/docs/index.html?q=ray#api/en/math/Ray) to intersect with
 - **materialOrSide**: [_Side_](https://threejs.org/docs/index.html?q=Materia#api/en/constants/Materials) | [_Material_](https://threejs.org/docs/index.html?q=Materia#api/en/materials/Material) | [_Material[]_](https://threejs.org/docs/index.html?q=Materia#api/en/materials/Material)
 
@@ -136,8 +131,7 @@ raycastFirst(
 
 Identical to `raycast` but stops at first intersection found.
 
-**Parameters**
-
+Parameters:
 - **ray**: [_Ray_](https://threejs.org/docs/index.html?q=ray#api/en/math/Ray) to intersect with
 - **materialOrSide**: [_Side_](https://threejs.org/docs/index.html?q=Materia#api/en/constants/Materials) | [_Material_](https://threejs.org/docs/index.html?q=Materia#api/en/materials/Material) | [_Material[]_](https://threejs.org/docs/index.html?q=Materia#api/en/materials/Material)
 
@@ -182,8 +176,7 @@ shapecast(
 
 Generic mechanism to intersect the BVH with various shapes/objects. The callbacks provide granular access to several stages of the BVH intersection process.
 
-**Parameters**
-
+Parameters:
 - **callbacks**: More details [_here_](https://github.com/gkjohnson/three-mesh-bvh/tree/master?tab=readme-ov-file#shapecast)
 
 **Returns**: boolean
@@ -206,8 +199,7 @@ Transform input vector, ray or box from world space into the acceleration struct
   this function implicitly.
 </Warning>
 
-**Parameters**
-
+Parameters:
 - **input**: [_Vector3_](https://threejs.org/docs/index.html?q=vec#api/en/math/Vector3) | [_Ray_](https://threejs.org/docs/index.html?q=ray#api/en/math/Ray) | [_Box3_](https://threejs.org/docs/index.html?q=box#api/en/math/Box3)
 
 **Returns**: [_Vector3_](https://threejs.org/docs/index.html?q=vec#api/en/math/Vector3) | [_Ray_](https://threejs.org/docs/index.html?q=ray#api/en/math/Ray) | [_Box3_](https://threejs.org/docs/index.html?q=box#api/en/math/Box3)
@@ -222,8 +214,7 @@ transformOutput<T extends Vector3 | Ray | Box3>(output: T): T
 
 Transform input vector, ray or box from the acceleration structure's space into world space.
 
-**Parameters**
-
+Parameters:
 - **input**: [_Vector3_](https://threejs.org/docs/index.html?q=vec#api/en/math/Vector3) | [_Ray_](https://threejs.org/docs/index.html?q=ray#api/en/math/Ray) | [_Box3_](https://threejs.org/docs/index.html?q=box#api/en/math/Box3)
   <Warning>
     All the AccelerationStructure methods that deal with querying the BVH:

--- a/developers/viewer/batch-object-api.mdx
+++ b/developers/viewer/batch-object-api.mdx
@@ -13,8 +13,7 @@ constructor(renderView: NodeRenderView, batchIndex: number)
 
 Populates/constructs this batch object.
 
-**Parameters**
-
+Parameters:
 - **renderView**: [_NodeRenderView_](/developers/viewer/render-view-api)
 - **batchIndex**: The object's index within its batch. Objects are placed in order inside the batch as they get processed
 
@@ -109,8 +108,7 @@ Build this object's [_AccelerationStructure_](/developers/viewer/acceleration-st
 The speckle viewer uses the [three-mesh-bvh](https://github.com/gkjohnson/three-mesh-bvh) library as the backbone for any BVH related operations.
 </Tip>
 
-**Parameters**
-
+Parameters:
 - _optional_ **bvh**: [_MeshBVH_](https://github.com/gkjohnson/three-mesh-bvh)
 
 **Returns**: void
@@ -128,8 +126,7 @@ public transformTRS(
 
 Used for transforming the object by using translation, rotation, scale and rotation pivot values.
 
-**Parameters**
-
+Parameters:
 - **translation**: The translation component of the transformation
 - _optional_ **euler**: Rotation component as euler angles in XYZ order
 - _optional_ **scale**: Scale component of the transformation

--- a/developers/viewer/extensions/diff-extension-api.mdx
+++ b/developers/viewer/extensions/diff-extension-api.mdx
@@ -18,8 +18,7 @@ async diff(
 
 Diffs the two speckle models provided as URLs. If the models are not yet loaded, they are also loaded.
 
-**Parameters**
-
+Parameters:
 - **urlA**: The 'current' model
 - **urlB**: The 'incoming' model
 - **mode**: The [_VisualDiffMode_](/developers/viewer/extensions/diff-extension-api#visualdiffmode)

--- a/developers/viewer/extensions/filtering-extension-api.mdx
+++ b/developers/viewer/extensions/filtering-extension-api.mdx
@@ -30,8 +30,7 @@ hideObjects(
 
 Hides the specified object ids.
 
-**Parameters**
-
+Parameters:
 - **objectIds**: The ids of the objects to hide
 - _optional_ **stateKey**: A way of splitting up commands coming from different controls (model explorer, filters, selection) so the viewer filtering api can know whether to reset its internal state or not
 - _optional_ **includeDescendants**: Whether to include the descendants of the provided object ids
@@ -52,8 +51,7 @@ isolateObjects(
 
 Hides the specified object ids.
 
-**Parameters**
-
+Parameters:
 - **objectIds**: The ids of the objects to hide
 - _optional_ **stateKey**: A way of splitting up commands coming from different controls (model explorer, filters, selection) so the viewer filtering api can know whether to reset its internal state or not
 - _optional_ **includeDescendants**: Whether to include the descendants of the provided object ids
@@ -99,8 +97,7 @@ setColorFilter(prop: PropertyInfo, ghost = true): FilteringState
 
 Applies a color filter.
 
-**Parameters**
-
+Parameters:
 - **prop**: [_PropertyInfo_](/developers/viewer/extensions/filtering-extension-api#propertyinfo)
 - _optional_ **ghost**" Whether to ghost the rest of the objects
 
@@ -118,8 +115,7 @@ Applies a user color filter.
 <Tip>
 If used appropriately user color filters can typically be much more performant than applying multiple materials per color.
 </Tip>
-**Parameters**
-
+Parameters:
 - **groups**: Groups of objects organized by color
 
 **Returns**: [_FilteringState_](/developers/viewer/extensions/filtering-extension-api#filteringstate-2)
@@ -136,8 +132,7 @@ showObjects(
 
 Shows the specified object ids.
 
-**Parameters**
-
+Parameters:
 - **objectIds**: The ids of the objects to hide
 - _optional_ **stateKey**: A way of splitting up commands coming from different controls (model explorer, filters, selection) so the viewer filtering api can know whether to reset its internal state or not
 - _optional_ **includeDescendants**: Whether to include the descendants of the provided object ids
@@ -157,8 +152,7 @@ unIsolateObjects(
 
 Shows the specified object ids.
 
-**Parameters**
-
+Parameters:
 - **objectIds**: The ids of the objects to hide
 - _optional_ **stateKey**: A way of splitting up commands coming from different controls (model explorer, filters, selection) so the viewer filtering api can know whether to reset its internal state or not
 - _optional_ **includeDescendants**: Whether to include the descendants of the provided object ids

--- a/developers/viewer/extensions/measurements-tool-api.mdx
+++ b/developers/viewer/extensions/measurements-tool-api.mdx
@@ -71,8 +71,7 @@ addMeasurement(data: MeasurementData): void
 
 Programatically adds a measurement from serializable measurement data.
 
-**Parameters**
-
+Parameters:
 - **data**: [_MeasurementData_](/developers/viewer/extensions/measurements-tool-api#measurementdata)
 
 **Returns**: void

--- a/developers/viewer/extensions/section-tool-api.mdx
+++ b/developers/viewer/extensions/section-tool-api.mdx
@@ -51,8 +51,7 @@ on(e: CameraEvent, handler: (data: boolean) => void)
 
 Function for subscribing to camera events.
 
-**Parameters**
-
+Parameters:
 - **e**: [_CameraEvent_](/developers/viewer/extensions/camera-controller-api#cameraevent)
 - **handler**: The handler for the events
 
@@ -66,8 +65,7 @@ removeListener(e: CameraEvent, handler: (data: unknown) => void)
 
 Function for un-subscribing from camera events.
 
-**Parameters**
-
+Parameters:
 - **e**: [_CameraEvent_](/developers/viewer/extensions/camera-controller-api#cameraevent)
 - **handler**: The handler for the events to unsubscribe
 
@@ -80,8 +78,7 @@ setBox(targetBox: Box3, offset = 0): void
 ```
 
 Sets the section box to the specified bounds
-**Parameters**
-
+Parameters:
 - **targetBox**: [_Box3_](https://threejs.org/docs/index.html?q=box3#api/en/math/Box3)
 - _optional_ **offset**: Linear tolerance
 

--- a/developers/viewer/extensions/selection-extension-api.mdx
+++ b/developers/viewer/extensions/selection-extension-api.mdx
@@ -74,8 +74,7 @@ selectObjects(ids: Array<string>, multiSelect = false): void
 
 Programatically selects objects by ids.
 
-**Parameters**
-
+Parameters:
 - **ids**: Array< string >
 - _optional_ **multiSelect**: Signals if this select needs to clear previous one or not
 
@@ -89,8 +88,7 @@ unselectObjects(ids?: Array<string>): void
 
 Programatically un-selects objects by ids.
 
-**Parameters**
-
+Parameters:
 - _optional_ **ids**: Array< string >. If not specified everything gets unselected
 
 **Returns**: void

--- a/developers/viewer/extensions/smooth-orbit-controls-api.mdx
+++ b/developers/viewer/extensions/smooth-orbit-controls-api.mdx
@@ -12,8 +12,7 @@ adjustOrbit(deltaTheta: number, deltaPhi: number, deltaZoom: number): void
 ```
 
 Used to adjust the current controler's target camera spherical coordinates by providing deltas.
-**Parameters**
-
+Parameters:
 - **deltaTheta**: The adjustment for the theta angle
 - **deltaPhi**: The adjustment for the phi angle
 - **deltaZoom**: The adjustment to the radius
@@ -28,8 +27,7 @@ setDamperDecayTime(decayMilliseconds: number)
 
 Sets the dampening values for the control. A larger smoothens out the camera's movement
 
-**Parameters**
-
+Parameters:
 - **decayMilliseconds**: Decay value
 
 **Returns**: void
@@ -42,8 +40,7 @@ setFieldOfView(fov: number)
 
 Sets the field of view when camera is [_PerspectiveCamera_](https://threejs.org/docs/index.html?q=persp#api/en/cameras/PerspectiveCamera)
 
-**Parameters**
-
+Parameters:
 - **fov**: Field of view value
 
 **Returns**: void
@@ -61,8 +58,7 @@ setOrbit(
 Set the absolute orbital goal of the camera. The change will be applied over a number of frames depending on configured dampening value. 
 Returns true if invoking the method will result in the camera changing position and/or rotation, otherwise false.
 
-**Parameters**
-
+Parameters:
 - **goalTheta**: Goal theta angle
 - **goalPhi**: Goal phi angle
 - **goalRadius**: Goal radius value

--- a/developers/viewer/extensions/speckle-controls-api.mdx
+++ b/developers/viewer/extensions/speckle-controls-api.mdx
@@ -79,8 +79,7 @@ All controls implementations need to be able to position and orient themselves a
   0)`
 </Warning>
 
-**Parameters**
-
+Parameters:
 - **sphere**: [_Sphere_](https://threejs.org/docs/index.html?q=sphere#api/en/math/Sphere)
 
 **Returns**: void
@@ -94,8 +93,7 @@ abstract fromPositionAndTarget(position: Vector3, target: Vector3): void
 Sets the controller's goal position and rotation based on a given location and another location to 'lookAt'. 
 All controls implementation need to be able to position and orient themselves according to these two vectors.
 
-**Parameters**
-
+Parameters:
 - **position**: The desired camera position as [_Vector3_](https://threejs.org/docs/index.html?q=vec#api/en/math/Vector3)
 - **target**: A position in space where the camera should 'lookAt' as [_Vector3_](https://threejs.org/docs/index.html?q=vec#api/en/math/Vector3)
   **Returns**: void
@@ -149,8 +147,7 @@ abstract update(delta?: number): boolean
 
 The control's update loop
 
-**Parameters**
-
+Parameters:
 - **delta**(_optional_): Frame delta time
 
 **Returns**: void

--- a/developers/viewer/geometry-converter-api.mdx
+++ b/developers/viewer/geometry-converter-api.mdx
@@ -23,8 +23,7 @@ abstract getSpeckleType(node: NodeData): SpeckleType
 
 Gets an opinionated [_SpeckleType_](/developers/viewer/geometry-converter-api#speckletype) based on the node's data.
 
-**Parameters**
-
+Parameters:
 - **node**: [_NodeData_](/developers/viewer/world-tree-api#nodedata)
 
 **Returns**: [_SpeckleType_](/developers/viewer/geometry-converter-api#speckletype)
@@ -37,8 +36,7 @@ abstract convertNodeToGeometryData(node: NodeData): GeometryData
 
 Takes in [_NodeData_](/developers/viewer/world-tree-api#nodedata) and outputs viewer defined geometry data.
 
-**Parameters**
-
+Parameters:
 - **node**: [_NodeData_](/developers/viewer/world-tree-api#nodedata)
 
 **Returns**: [_GeometryData_](/developers/viewer/render-view-api#geometrydata)
@@ -49,8 +47,7 @@ Takes in [_NodeData_](/developers/viewer/world-tree-api#nodedata) and outputs vi
 abstract disposeNodeGeometryData(node: NodeData): void
 ```
 
-**Parameters**
-
+Parameters:
 - **node**: [_NodeData_](/developers/viewer/world-tree-api#nodedata)
   Disposes the explicit node data geometry
 

--- a/developers/viewer/intersections-api.mdx
+++ b/developers/viewer/intersections-api.mdx
@@ -37,8 +37,7 @@ Scene intersect function.
 All intersect calls from this class will use the available acceleration structures. This makes the intersection **significantly** faster than using your own three.js raycasters.
 </Tip>
 
-**Parameters**
-
+Parameters:
 - **scene**: [_Scene_](https://threejs.org/docs/index.html?q=scene#api/en/scenes/Scene)
 - **camera**: [_Camera_](https://threejs.org/docs/index.html?q=camera#api/en/cameras/Camera)
 - **point**: The NDC point to cast the ray from
@@ -80,8 +79,7 @@ Scene intersect function using a provided Ray.
 All intersect calls from this class will use the available acceleration structures. This makes the intersection **significantly** faster than using your own three.js raycasters.
 </Tip>
 
-**Parameters**
-
+Parameters:
 - **scene**: [_Scene_](https://threejs.org/docs/index.html?q=scene#api/en/scenes/Scene)
 - **camera**: [_Camera_](https://threejs.org/docs/index.html?q=camera#api/en/cameras/Camera)
 - **ray**: The ray to use for casting

--- a/developers/viewer/loader-api.mdx
+++ b/developers/viewer/loader-api.mdx
@@ -14,8 +14,7 @@ constructor(resource: string, resourceData?: string | ArrayBuffer)
 
 Populates the loader with data.
 
-**Parameters**
-
+Parameters:
 - **resource**: This can either be a resource URL, either an resource ID
 - _(optional)_ **resourceData**: Explicit data you want to load
 

--- a/developers/viewer/rendering-pipeline-api/pipeline-api.mdx
+++ b/developers/viewer/rendering-pipeline-api/pipeline-api.mdx
@@ -11,8 +11,7 @@ description: Abstract class that is the base for all concrete rendering pipeline
         constructor(speckleRenderer: SpeckleRenderer)
         ```
 
-**Parameters**
-
+Parameters:
 - **speckleRenderer**: The hosting renderer as [SpeckleRenderer](/developers/viewer/speckle-renderer-api)
 
 ## Properties
@@ -91,8 +90,7 @@ Creates an MRT enabled three.js render target.
   documentation. However it works similarly to the regular `WebGLRenderTarget`
 </Warning>
 
-**Parameters**
-
+Parameters:
 - **count**: The number of color attachements to the framebuffer
 - **options**: [WebGLRenderTargetOptions](https://threejs.org/docs/index.html?q=webgl#api/en/renderers/WebGLRenderTarget)
 - **width**: If none specified it will default to `1`
@@ -123,8 +121,7 @@ Creates a three.js render target.
   documentation. However it works similarly to the regular `WebGLRenderTarget`
 </Warning>
 
-**Parameters**
-
+Parameters:
 - **options**: [`WebGLRenderTargetOptions`](https://threejs.org/docs/index.html?q=webgl#api/en/renderers/WebGLRenderTarget)
 - **width**: If none specified it will default to `1`
 - **height**: If none specified it will default to `1`
@@ -139,8 +136,7 @@ getPass(name: string): GPass[]
 
 Get's all the passes with the provided name
 
-**Parameters**
-
+Parameters:
 - **name**: The name of the pass to get
 
 **Returns**: [`GPass[]`](/developers/viewer/rendering-pipeline-api/g-pass-api)
@@ -193,8 +189,7 @@ Resets the pipeline
 
 **Returns**: void
 
-**Parameters**
-
+Parameters:
 - **width**: The new width of the pipeline
 - **height**: The new height of the pipeline
 
@@ -208,8 +203,7 @@ setClippingPlanes(planes: Plane[]): void
 
 Propagates clipping planes towards the pipeline's consituent passes
 
-**Parameters**
-
+Parameters:
 - **planes**: The clipping [`Planes`](https://threejs.org/docs/index.html?q=plane#api/en/math/Plane)
 
 **Returns**: void

--- a/developers/viewer/rendering-pipeline-api/progressive-pipeline-api.mdx
+++ b/developers/viewer/rendering-pipeline-api/progressive-pipeline-api.mdx
@@ -29,8 +29,7 @@ but they can share pass instances between them if necessary. At any given time t
 constructor(speckleRenderer: SpeckleRenderer)
 ```
 
-**Parameters**
-
+Parameters:
 - **speckleRenderer**: The hosting renderer as [`SpeckleRenderer`](/developers/viewer/speckle-renderer-api)
 
 ## Properties

--- a/developers/viewer/speckle-material-api.mdx
+++ b/developers/viewer/speckle-material-api.mdx
@@ -83,8 +83,7 @@ fastCopy(from: Material, to: Material)
 
 Copies properties from one _from_ Material to _to_ Material. The data copied over is restricted to no more and no less than what the viewer needs, so unlike three.js default material copying this aims to be as fast as possible.
 
-**Parameters**
-
+Parameters:
 - **from**: [_Material_](https://threejs.org/docs/index.html?q=materi#api/en/materials/Material)
 - **to**: [_Material_](https://threejs.org/docs/index.html?q=materi#api/en/materials/Material)
 

--- a/developers/viewer/world-tree-api.mdx
+++ b/developers/viewer/world-tree-api.mdx
@@ -45,8 +45,7 @@ addNode(node: TreeNode, parent: TreeNode): void
 
 Adds a [_TreeNode_](/developers/viewer/world-tree-api#treenode) as a child of the provided parent node.
 
-**Parameters**
-
+Parameters:
 - **node**: The [_TreeNode_](/developers/viewer/world-tree-api#treenode) to add
 - **parent**: The parent [_TreeNode_](/developers/viewer/world-tree-api#treenode) to add the node to
 
@@ -63,8 +62,7 @@ The world tree can be split into subtrees, each of which will have it's dedicate
 _NodeMap_ for optimal searching speed. A subtree does not differ structurally from 
 a regular node, and it does not alter the overall hierarchy of the world tree in any way.
 
-**Parameters**
-
+Parameters:
 - **node**: The [_TreeNode_](/developers/viewer/world-tree-api#treenode) to add as a subtree
 
 **Returns**: void
@@ -84,8 +82,7 @@ can lock the main thread for too long. If you need to execute complex predicates
 on large trees, [_walkAsync_](/developers/viewer/world-tree-api#walkasync) is a better candidate.
 </Warning>
 
-**Parameters**
-
+Parameters:
 - **predicate**: The [_SearchPredicate_](/developers/viewer/world-tree-api#searchpredicate) 
   to run for each node
 - _(optional)_ **node**: The [_TreeNode_](/developers/viewer/world-tree-api#treenode) to 
@@ -107,8 +104,7 @@ Using this method for tree searches is encouraged because it's accelerated by a
 backing _NodeMap_ which brings down searches to just one or more lookups
 </Tip>
 
-**Parameters**
-
+Parameters:
 - **id**: The id of the node to search for
 - _(optional)_ **subtreeId**: The id of the subtree to search in. If _undefined_ 
   the search will include the entire tree
@@ -123,8 +119,7 @@ getAncestors(node: TreeNode): TreeNode[]
 
 Gets the full list of node ancestors in hierarchical order.
 
-**Parameters**
-
+Parameters:
 - **node**: The node to search ancestors for
 
 **Returns**: [_TreeNode_](/developers/viewer/world-tree-api#treenode)[]
@@ -137,8 +132,7 @@ getInstances(subtree: string): { [id: string]: Record<string, TreeNode> }
 
 Gets all the instances in the provided subtree id.
 
-**Parameters**
-
+Parameters:
 - **subtree**: The root subtree id
 
 **Returns**: A dictionary where each instance id holds a record of 
@@ -155,8 +149,7 @@ Gets the [_RenderTree_](/developers/viewer/render-tree-api) instance of the prov
 If the subtree id is not found, `null` is returned. The overloaded version with 
 no argument gets the _RenderTree_ instance for the entire tree, which can never be null. 
 
-**Parameters**
-
+Parameters:
 - **subtreeId**: The root subtree id
 
 **Returns**: [_RenderTree_](/developers/viewer/render-tree-api)
@@ -169,8 +162,7 @@ isRoot(node: TreeNode): boolean
 
 Checks is a [_TreeNode_](/developers/viewer/world-tree-api#treenode) is root.
 
-**Parameters**
-
+Parameters:
 - **node**: [_TreeNode_](/developers/viewer/world-tree-api#treenode)
 
 **Returns**: boolean
@@ -195,8 +187,7 @@ The input model needs to follow the form.
 
 The input _model_ can contain virtually anything, but it should have at least the properties defined above.
 
-**Parameters**
-
+Parameters:
 - **node**: `{ id: string, raw?: object, atomic?: boolean, children: []}`
 
 **Returns**: [_TreeNode_](/developers/viewer/world-tree-api#treenode)
@@ -212,8 +203,7 @@ Destroys part of the tree, or in the absence of a _subtreeId_ argument, the enti
 Purged trees are no longer usable!
 </Warning>
 
-**Parameters**
-
+Parameters:
 - _optional_ **subtreeId**: The subtree root id. If undefined the whole tree will get purged
 
 **Returns**: void
@@ -226,8 +216,7 @@ removeNode(node: TreeNode): void
 
 Removed the provided [_TreeNode_](/developers/viewer/world-tree-api#treenode) from the tree.
 
-**Parameters**
-
+Parameters:
 - **node**: [_TreeNode_](/developers/viewer/world-tree-api#treenode)
 
 **Returns**: void
@@ -249,8 +238,7 @@ number of nodes, it might block the main thread. For a heavy
 [_walkAsync_](/developers/viewer/world-tree-api#walkasync).
 </Warning>
 
-**Parameters**
-
+Parameters:
 - **predicate**: [_SearchPredicate_](/developers/viewer/world-tree-api#searchpredicate)
 - _optional_ **node**: [_TreeNode_](/developers/viewer/world-tree-api#treenode)
 
@@ -267,8 +255,7 @@ will yield for 16ms (one frame) after a cummulated 100ms spent executing. The re
 promise will resolve to a boolean which determines if the tree was completely 
 walked (true) or not (false).
 
-**Parameters**
-
+Parameters:
 - **predicate**: [_SearchPredicate_](/developers/viewer/world-tree-api#searchpredicate)
 - _optional_ **node**: [_TreeNode_](/developers/viewer/world-tree-api#treenode)
 

--- a/legacy/user/qgis.mdx
+++ b/legacy/user/qgis.mdx
@@ -178,27 +178,27 @@ Add "Log Messages Panel" to your QGIS interface to see more info and warnings ab
 
 ### Examples
 
-**Elevation to a 3d mesh**
+Elevation to a 3d mesh:
 <Frame>
   <img src="/images/legacy/qgis/2.14-changelog-01-elevation.gif" alt="2.14-changelog-01-elevation" />
 </Frame>
 
-**Texture for 3d mesh**
+Texture for 3d mesh:
 <Frame>
   <img src="/images/legacy/qgis/2.14-changelog-02-texture_over_elevation.gif" alt="2.14-changelog-02-texture" />
 </Frame>
 
-**Polygon extrusions**
+Polygon extrusions:
 <Frame>
   <img src="/images/legacy/qgis/2.14-changelog-03-extrusion.gif" alt="2.14-changelog-03-extrusion" />
 </Frame>
 
-**Extruding and projecting on a terrain**
+Extruding and projecting on a terrain:
 <Frame>
   <img src="/images/legacy/qgis/2.14-changelog-04-extrude_and_project_smaller_smaller.gif" alt="2.14-changelog-04-projecting" />
 </Frame>
 
-**Combination of the transformations**
+Combination of the transformations:
 <Frame>
   <img src="/images/legacy/qgis/2.14-changelog-05-altogether_smaller.gif" alt="2.14-changelog-05-all-transforms" />
 </Frame>

--- a/legacy/user/revit/faq.mdx
+++ b/legacy/user/revit/faq.mdx
@@ -36,13 +36,13 @@ import LegacyVersions from '/snippets/legacy-versions.mdx'
 <Accordion title="How to uninstall Revit connector?">
   You can uninstall Revit connector either using Manager or from the Installed Apps dialog.
 
-  **Deleting via Manager**
+  Deleting via Manager:
 
   1. Open **Manager**.
   2. Select **Revit Connector**.
   3. Click **Uninstall**.
 
-  **Deleting from installed apps**
+  Deleting from installed apps:
 
   1. In the Windows search bar, search and select "**Add or Remove Programs**".
   2. Search for **Speckle for Revit.**

--- a/legacy/user/revit/features.mdx
+++ b/legacy/user/revit/features.mdx
@@ -54,8 +54,7 @@ All the other Revit parameters, both **type and instance**, are nested inside th
 
 The connector takes care of updating received elements automatically where possible (instead of deleting and re-creating them). This is preferred, as Dimensions, ElementIds, and other annotations are preserved.
 
-**Elements are updated under these two circumstances:**
-
+Elements are updated under these two circumstances:
 - If the element was created in another project/software and had been received previously: for example, BuiltElements that were created in Rhino or Grasshopper.
 - If the element was created in the same project you're working on: for example, if you send some walls to Speckle, edit them, and receive them again from the same model
 

--- a/migration/connectors-v2-to-v3.mdx
+++ b/migration/connectors-v2-to-v3.mdx
@@ -4,10 +4,10 @@ sidebarTitle: Legacy to current connectors
 ---
 
 <Danger>
-  **Legacy connectors will be deprecated on January 1, 2026**
+  Legacy connectors will be deprecated on January 1, 2026:
 </Danger>
 
-**Do this now:**
+Do this now:
 - [Assess your workflow](#assess-your-workflow) to see if you can migrate
 - [Download legacy installers](https://releases.speckle.systems/legacy-connectors) you still need (available until Jan 1, 2026)
 - [Start your migration](#migration-steps) if your workflow is supported
@@ -46,8 +46,7 @@ These workflows have full support in V3 connectors:
 
 These workflows currently require legacy connectors:
 
-**Connectors without V3 versions**
-
+Connectors without V3 versions:
 | Connector | Status | Action |
 |-----------|--------|--------|
 | Excel | ⏸️ Legacy only | Download installer before Jan 1, 2026 |
@@ -59,8 +58,7 @@ These workflows currently require legacy connectors:
 | Advance Steel | ⏸️ Legacy only | Download installer before Jan 1, 2026 |
 | Bentley products | ⏸️ Legacy only | MicroStation, OpenRoads, OpenRail, OpenBuilding |
 
-**Native BIM element workflows**
-
+Native BIM element workflows:
 These workflows load models as native BIM elements and currently require legacy connectors:
 
 | From | To | Status |
@@ -70,10 +68,10 @@ These workflows load models as native BIM elements and currently require legacy 
 | Revit | Revit (native elements) | ⏸️ Legacy only |
 | Civil 3D | Revit | ⏸️ Legacy only |
 
-**Platform limitations**
+Platform limitations:
 - Mac versions of Rhino and ArchiCAD require legacy connectors
 
-**What to do:**
+What to do:
 1. Download necessary installers before January 1, 2026 and save them securely
 2. Complete existing projects on your current timeline
 3. Avoid starting new projects with legacy connectors
@@ -113,13 +111,13 @@ Because legacy and V3 connectors use different data models, you need to resend y
 
 ## Get migration support
 
-**Community support**  
+Community support:
 Visit our [Community Forum](https://speckle.community) for migration questions and tips. Active support available until January 1, 2026.
 
-**Documentation**  
+Documentation:
 Explore connector-specific guides in the [Connectors section](/connectors/overview).
 
-**Paid workspace support**  
+Paid workspace support:
 Contact your workspace administrator to arrange dedicated migration assistance.
 
 

--- a/migration/personal-projects.mdx
+++ b/migration/personal-projects.mdx
@@ -13,8 +13,7 @@ import ProjectMigration from '/snippets/faqs/project-migration.mdx';
   moved into a workspace, which is now the default.
 </Warning>
 
-**What to do to keep your projects:**
-
+What to do to keep your projects:
 1. **Create or join a workspace** - Workspaces are now the default for all new projects. 
    Choose the Explore plan or contact us to set up a workspace that accommodates all your projects.
 
@@ -53,12 +52,10 @@ With the full release of workspace-based collaboration, personal projects in Spe
 
 <Step title="Move projects into your workspace">
 
-**From the workspace page.**
-
+From the workspace page.:
 You can select **Add Project** to create a new project or move an existing one. You will be presented with a full list of all your personal projects.
 
-**From the personal project page.**
-
+From the personal project page.:
 For each project, click the **Move** button and you will be presented with a list of any workspaces you are the admin of.
 
 </Step>

--- a/snippets/faqs/project-migration.mdx
+++ b/snippets/faqs/project-migration.mdx
@@ -1,12 +1,12 @@
 <AccordionGroup>
   <Accordion title="🚨 Critical: Personal Projects Will Be Deleted on January 1, 2026">
     <Warning>
-      **All personal projects in Speckle will be permanently deleted on January 1, 2026.** 
+      All personal projects in Speckle will be permanently deleted on January 1, 2026.:
       It will not be possible to recover them after that time. This refers to any Speckle 
       projects in the "Personal project" section that haven't been moved into a workspace.
     </Warning>
     
-    **What to do to keep your projects:**
+    What to do to keep your projects:
     
     1. **Create or join a workspace** - Workspaces are now the default for all new projects. 
        Choose the Explore plan or contact us to set up a workspace that accommodates all your projects.

--- a/workspaces/it-setup.mdx
+++ b/workspaces/it-setup.mdx
@@ -50,8 +50,7 @@ This guide consolidates all technical setup requirements for IT teams deploying 
 Speckle connectors enable users to publish and load data from design applications like Revit, Rhino, and Archicad.
 
 <Warning>
-**Connector updates work in two parts:**
-
+Connector updates work in two parts:
 - **Desktop UI (DUI)**: Updated centrally and automatically propagates to all connectors without requiring connector updates. This shared interface handles authentication and common workflows.
 - **Connector addons**: Updated separately for each connector. Each application-specific connector (Revit, Rhino, etc.) must be updated individually.
 
@@ -60,8 +59,7 @@ When deploying connectors manually, you only need to update connector addons. DU
 </Warning>
 
 <Note>
-**Update cadence and approval processes:**
-
+Update cadence and approval processes:
 Speckle connectors are updated frequently to maintain compatibility with the evergreen Speckle server. Connectors are open source and can be inspected for security and compliance. If your organization requires approval for every software update, factor this frequent update cadence into your deployment process. Consider establishing a streamlined approval workflow or allowing automatic updates for patch releases.
 
 The Speckle server is also open source with delayed releases, allowing you to inspect changes before deployment if you're running a self-hosted instance.
@@ -153,25 +151,20 @@ Allow outbound HTTPS (port 443) connections to:
 
 The following endpoints must be accessible for full functionality:
 
-**GraphQL API:**
-
+GraphQL API:
 - `https://app.speckle.systems/graphql`
 
-**REST API:**
-
+REST API:
 - `https://app.speckle.systems/api/v1/*`
 
-**Authentication:**
-
+Authentication:
 - `https://app.speckle.systems/api/v1/auth/*`
 - `https://app.speckle.systems/api/v1/workspaces/*/sso/oidc/callback` (for SSO)
 
-**WebSocket (for real-time features):**
-
+WebSocket (for real-time features):
 - Allow WebSocket connections (WSS) to `app.speckle.systems` for real-time features in the web application
 
-**File uploads:**
-
+File uploads:
 - File uploads use presigned S3 URLs that are generated dynamically. These are typically served through `app.speckle.systems` or associated CDN endpoints. If you encounter issues with file uploads, ensure `app.speckle.systems` and its associated CDN domains (including `*.digitaloceanspaces.com`) are fully allowlisted.
 
 ### Self-hosted servers

--- a/workspaces/versions.mdx
+++ b/workspaces/versions.mdx
@@ -56,8 +56,7 @@ In the web interface you can open versions from **several** places. On any
 version row, open the **...** menu at the end of the row for actions (labels
 match the product).
 
-**Row menu actions**
-
+Row menu actions:
 - **Edit message...** — change the version note after publish.
 - **Move to...** — move this version to another model in the project.
 - **Copy link** / **Copy ID** — copy the viewer URL or raw version id (for


### PR DESCRIPTION
Replace lone **Emphasis** lines used as fake headings with Label: text so markdownlint MD036 passes across the docs tree.