### PR TITLE
ci: require Accessibility; finish Prettier stragglers

### DIFF
--- a/.github/workflows/docs-pr-checks.yml
+++ b/.github/workflows/docs-pr-checks.yml
@@ -1,8 +1,8 @@
-# Docs PR checks: Format and lint (changed files), Mintlify validate, and Broken
-# links are blocking. Accessibility runs with continue-on-error until required.
+# Docs PR checks: Format and lint (changed files), Mintlify validate, Broken
+# links, and Accessibility are blocking.
 #
-# Branch protection: require "Mintlify validate", "Broken links", and
-# "Format and lint" (see scripts/enable-required-pr-checks.sh).
+# Branch protection: require "Mintlify validate", "Broken links",
+# "Format and lint", and "Accessibility" (see scripts/enable-required-pr-checks.sh).
 
 name: Docs PR checks
 
@@ -14,7 +14,10 @@ on:
       - '**/*.jsx'
       - '**/*.tsx'
       - '**/*.js'
+      - '**/*.mjs'
+      - '**/*.cjs'
       - '**/*.ts'
+      - '**/*.css'
       - '**/*.json'
       - '**/*.jsonc'
       - 'docs.json'
@@ -150,7 +153,6 @@ jobs:
     name: Accessibility
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
 
     steps:
       - name: Checkout
@@ -177,5 +179,5 @@ jobs:
           {
             echo '## Accessibility (full site)'
             echo ''
-            echo '`mint a11y` — report-only (`continue-on-error`); not required yet.'
+            echo '`mint a11y` — blocking; required status check on `main`.'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.universal-ai-config/skills/docs-ci-ready/SKILL.md
+++ b/.universal-ai-config/skills/docs-ci-ready/SKILL.md
@@ -21,7 +21,7 @@ Work from the **docs package root** (`speckle-docs-NEW`). Do not edit sibling wo
 
 ## Commands (match CI)
 
-Validate, broken links, and format-lint (changed files) are **blocking**. Accessibility stays report-only until Phase 2c. Prefer changed-file scripts for format/lint; full-tree lint is optional.
+Validate, broken links, format-lint (changed files), and accessibility are **blocking**. Prefer changed-file scripts for format/lint; full-tree lint is optional.
 
 ```bash
 pnpm check                       # CI-equivalent (changed format/lint + validate + links + a11y)
@@ -55,9 +55,9 @@ pnpm format
 2. **Prettier** — then re-run validate (format can break MDX; see footguns)
 3. **Broken links** (`pnpm check-links`) — includes redirects and Snippet links
 4. **Markdownlint** on changed files — blocking in CI and pre-commit; fix before push
-5. **a11y** (`pnpm check:a11y`) — fix alts on pages you touch; full-site gate is still Phase 2c
+5. **a11y** (`pnpm check:a11y`) — blocking; fix missing alts and related issues before push
 
-Stop when `pnpm check:changed` is green (or only remaining failure is known a11y debt the user accepts).
+Stop when `pnpm check:changed` is green.
 
 ## Footguns (learned the hard way)
 
@@ -122,6 +122,6 @@ Commit generated outputs only if this repo tracks them. Never hand-edit generate
 - `pnpm check:links` succeeds
 - `pnpm format:check:changed` succeeds for the PR range
 - markdownlint on changed files succeeds (blocking)
-- `pnpm check:a11y`: fixed for touched pages or left as known Phase 2c debt
+- `pnpm check:a11y` succeeds (blocking)
 
-Report which commands passed and any remaining intentional a11y debt.
+Report which commands passed.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Pull requests run [`.github/workflows/docs-pr-checks.yml`](.github/workflows/doc
 - **Format and lint** — `pnpm format:check:changed` + `pnpm lint:md:changed` (PR files only; **blocking**)
 - **Mintlify validate** — `pnpm valid` (full site; **blocking**)
 - **Broken links** — `pnpm check-links` (anchors + redirects + Snippet links; full site; **blocking**)
-- **Accessibility** — `pnpm check:a11y` (`mint a11y`; full site; report-only)
+- **Accessibility** — `pnpm check:a11y` (`mint a11y`; full site; **blocking**)
 
 Require the blocking jobs on `main`:
 
@@ -82,7 +82,7 @@ Require the blocking jobs on `main`:
 bash scripts/enable-required-pr-checks.sh
 ```
 
-(Needs `gh auth login` with repo admin.) Or set branch protection manually to require status checks **Mintlify validate**, **Broken links**, and **Format and lint**.
+(Needs `gh auth login` with repo admin.) Or set branch protection manually to require status checks **Mintlify validate**, **Broken links**, **Format and lint**, and **Accessibility**.
 
 Scheduled / manual ([`.github/workflows/docs-scheduled-checks.yml`](.github/workflows/docs-scheduled-checks.yml)):
 
@@ -117,8 +117,6 @@ pnpm lint:md:all           # markdownlint entire tree
 pnpm format
 pnpm lint:md:fix
 ```
-
-Accessibility still uses `continue-on-error` in CI. Drop that and require the job in branch protection when ready to gate on a11y.
 
 ### Generating universal-ai-config instructions
 

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,11 +1,11 @@
 /**
- * Staged-file format/lint — aligned with CI Format and lint (Phase 2b).
+ * Staged-file format/lint — aligned with CI Format and lint.
  * - Prettier: blocking (auto-writes)
  * - markdownlint: blocking on staged markdown (matches CI changed-file gate)
  * Does not run mint validate / links / a11y.
  */
 
-const prettierGlobs = '*.{md,mdx,js,jsx,ts,tsx,json,jsonc,yml,yaml}'
+const prettierGlobs = '*.{md,mdx,js,jsx,mjs,cjs,ts,tsx,json,jsonc,yml,yaml,css}'
 
 /** Paths markdownlint should skip (same idea as scripts/lint-md-changed.sh). */
 function shouldLintMarkdown(file) {

--- a/scripts/align-md-tables.mjs
+++ b/scripts/align-md-tables.mjs
@@ -37,7 +37,6 @@ function loadStringWidth() {
 const stringWidthMod = loadStringWidth()
 const stringWidth = stringWidthMod.default ?? stringWidthMod
 
-
 function isSepCell(c) {
   const t = c.trim().replace(/ /g, '')
   return /^:?-{3,}:?$/.test(t)

--- a/scripts/enable-required-pr-checks.sh
+++ b/scripts/enable-required-pr-checks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Require Docs PR check jobs on main (validate + links + format-lint).
+# Require Docs PR check jobs on main (validate + links + format-lint + a11y).
 # Leaves enforce_admins off so repo admins can still bypass when needed.
 # Needs: gh auth login with admin on specklesystems/speckle-docs-NEW
 #
@@ -12,7 +12,7 @@ REPO="${REPO:-specklesystems/speckle-docs-NEW}"
 BRANCH="${BRANCH:-main}"
 
 echo "Updating branch protection on ${REPO}@${BRANCH}"
-echo "Required status checks: Mintlify validate, Broken links, Format and lint"
+echo "Required status checks: Mintlify validate, Broken links, Format and lint, Accessibility"
 
 gh api \
   --method PUT \
@@ -22,7 +22,7 @@ gh api \
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["Mintlify validate", "Broken links", "Format and lint"]
+    "contexts": ["Mintlify validate", "Broken links", "Format and lint", "Accessibility"]
   },
   "enforce_admins": false,
   "required_pull_request_reviews": {

--- a/scripts/format-check-changed.sh
+++ b/scripts/format-check-changed.sh
@@ -30,7 +30,7 @@ while IFS= read -r file; do
   files[${#files[@]}]="$file"
 done <<EOF
 $(git diff --name-only --diff-filter=ACMRT "$RANGE" -- \
-  '*.md' '*.mdx' '*.js' '*.jsx' '*.ts' '*.tsx' '*.json' '*.jsonc' '*.yml' '*.yaml' \
+  '*.md' '*.mdx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.ts' '*.tsx' '*.json' '*.jsonc' '*.yml' '*.yaml' '*.css' \
   || true)
 EOF
 

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-#footer div:first-child > div:first-child > div:first-child  {
+#footer div:first-child > div:first-child > div:first-child {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- Format leftover Prettier debt (`scripts/align-md-tables.mjs`, `style.css`) so `pnpm format:check` is clean.
- Extend changed-file / lint-staged Prettier globs to include `.mjs`, `.cjs`, `.css`.
- Make the **Accessibility** CI job blocking and add it to `enable-required-pr-checks.sh`.
- Update README + docs-ci-ready skill; drop stale report-only / Phase wording.

## Test plan
- [x] `pnpm format:check`
- [x] `pnpm lint:md:all`
- [x] `pnpm check:a11y` (exit 0)
- [x] CI Docs PR checks all green
- [x] After merge: `bash scripts/enable-required-pr-checks.sh` (adds Accessibility; keeps `enforce_admins` false)


Made with [Cursor](https://cursor.com)