### PR TITLE
chore: refresh Dev Container for Node 22 and pnpm mint

### DIFF
--- a/.devcontainer/.zshrc
+++ b/.devcontainer/.zshrc
@@ -2,7 +2,8 @@ HISTFILE=$HOME/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000
 
-setopt INC_APPEND_HISTORY   # write each command as you go
-setopt SHARE_HISTORY        # pull in commands from other sessions
+setopt INC_APPEND_HISTORY
+setopt SHARE_HISTORY
 
+# Uses package.json "dev" (mint on port 3333). Polling helps file watch in containers.
 alias mintdev='CHOKIDAR_USEPOLLING=true pnpm dev'

--- a/.devcontainer/.zshrc
+++ b/.devcontainer/.zshrc
@@ -1,9 +1,0 @@
-HISTFILE=$HOME/.zsh_history
-HISTSIZE=10000
-SAVEHIST=10000
-
-setopt INC_APPEND_HISTORY
-setopt SHARE_HISTORY
-
-# Uses package.json "dev" (mint on port 3333). Polling helps file watch in containers.
-alias mintdev='CHOKIDAR_USEPOLLING=true pnpm dev'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,32 +1,28 @@
-ARG VARIANT=20
+ARG VARIANT=22
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
-# Install dependencies with root
 USER root
 
 RUN apt-get update \
     && apt-get install -y zsh git curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Set pnpm global bin to a shared location on PATH
+# Match package.json packageManager (corepack); project mint comes from pnpm install
 ENV PNPM_HOME=/usr/local/share/pnpm
 ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
 
-# Install Mintlify CLI
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm add -g mint@latest
-
-# Because Jonathon likes to use ZSH
 ENV ZSH=/home/node/.oh-my-zsh
 RUN if [ ! -d "${ZSH}" ]; then \
       git clone https://github.com/ohmyzsh/ohmyzsh.git "${ZSH}"; \
     fi \
     && cp "${ZSH}/templates/zshrc.zsh-template" /home/node/.zshrc \
     && sed -i 's|^export ZSH=.*|export ZSH="'"${ZSH}"'"|' /home/node/.zshrc \
-    && sed -i 's|^ZSH_THEME=.*|ZSH_THEME="robbyrussell"|' /home/node/.zshrc \
-    && echo "alias mintdev='CHOKIDAR_USEPOLLING=true mint dev --verbose'" \
-       >> /home/node/.zshrc
+    && sed -i 's|^ZSH_THEME=.*|ZSH_THEME="robbyrussell"|' /home/node/.zshrc
 
-RUN chown -R node:node /home/node
+COPY .zshrc /tmp/devcontainer.zshrc
+RUN cat /tmp/devcontainer.zshrc >> /home/node/.zshrc \
+    && rm /tmp/devcontainer.zshrc \
+    && chown -R node:node /home/node
 
-# Revert to the non-root user for security
 USER node

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,26 +3,9 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 USER root
 
-RUN apt-get update \
-    && apt-get install -y zsh git curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Match package.json packageManager (corepack); project mint comes from pnpm install
+# Match package.json packageManager; project mint comes from pnpm install
 ENV PNPM_HOME=/usr/local/share/pnpm
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
-
-ENV ZSH=/home/node/.oh-my-zsh
-RUN if [ ! -d "${ZSH}" ]; then \
-      git clone https://github.com/ohmyzsh/ohmyzsh.git "${ZSH}"; \
-    fi \
-    && cp "${ZSH}/templates/zshrc.zsh-template" /home/node/.zshrc \
-    && sed -i 's|^export ZSH=.*|export ZSH="'"${ZSH}"'"|' /home/node/.zshrc \
-    && sed -i 's|^ZSH_THEME=.*|ZSH_THEME="robbyrussell"|' /home/node/.zshrc
-
-COPY .zshrc /tmp/devcontainer.zshrc
-RUN cat /tmp/devcontainer.zshrc >> /home/node/.zshrc \
-    && rm /tmp/devcontainer.zshrc \
-    && chown -R node:node /home/node
 
 USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,14 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "VARIANT": "20"
+      "VARIANT": "22"
+    }
+  },
+  "forwardPorts": [3333],
+  "portsAttributes": {
+    "3333": {
+      "label": "Mintlify",
+      "onAutoForward": "notify"
     }
   },
   "customizations": {
@@ -15,20 +22,19 @@
             "args": ["-l"]
           }
         },
-        "terminal.integrated.defaultProfile.linux": "zsh"
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true
       },
       "extensions": [
-        "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "mintlify.mintlify-vscode",
         "mintlify.mintlify-snippets",
-        "mintlify.document",
-        "unifiedjs.vscode-mdx",
-        "nuxt.mdc"
+        "unifiedjs.vscode-mdx"
       ]
     }
   },
   "mounts": ["source=speckle-docs-zsh-history,target=/home/node/.zsh_history,type=volume"],
-  "postCreateCommand": "if [ -f package.json ]; then pnpm install || exit 1; else echo 'No package.json, skipping pnpm install'; fi; CHOKIDAR_USEPOLLING=true mint dev --verbose",
+  "postCreateCommand": "pnpm install",
   "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,13 +16,6 @@
   "customizations": {
     "vscode": {
       "settings": {
-        "terminal.integrated.profiles.linux": {
-          "zsh": {
-            "path": "/usr/bin/zsh",
-            "args": ["-l"]
-          }
-        },
-        "terminal.integrated.defaultProfile.linux": "zsh",
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
       },
@@ -34,7 +27,6 @@
       ]
     }
   },
-  "mounts": ["source=speckle-docs-zsh-history,target=/home/node/.zsh_history,type=volume"],
   "postCreateCommand": "pnpm install",
   "remoteUser": "node"
 }

--- a/README.md
+++ b/README.md
@@ -166,15 +166,18 @@ Install our GitHub App to auto-propagate changes from your repo to your deployme
 
 ### Optional: Using Devcontainers
 
-This repository also includes a devcontainer/Dockerfile setup. It provides a pre-configured environment with Node, Mintlify, and ZSH installed, along with a convenient `mintdev` alias.
+This repository includes a Dev Container (Node **22**, pnpm, zsh) aligned with CI and `package.json`.
 
-- To use it in VS Code, open the repo and choose **Reopen in Container**. The devcontainer will build itself.
-- Once inside the container, run:
+- In VS Code / Cursor: **Reopen in Container**. The image builds, then `pnpm install` runs.
+- Port **3333** is forwarded for the Mintlify preview.
+- Mint comes from the project (`pnpm install`), not a global CLI baked into the image.
+
+Inside the container:
 
 ```bash
 mintdev
 ```
 
-This will start Mintlify in verbose mode with polling enabled, ensuring file changes are picked up reliably.
+That runs `pnpm dev` (Mintlify on port 3333) with file-watch polling enabled.
 
-Using the devcontainer is optional but recommended if you want a consistent, containerised environment without managing Node or Mintlify versions on your local machine.
+Dev Containers are optional; useful for a consistent environment without managing Node or pnpm locally.

--- a/README.md
+++ b/README.md
@@ -166,18 +166,16 @@ Install our GitHub App to auto-propagate changes from your repo to your deployme
 
 ### Optional: Using Devcontainers
 
-This repository includes a Dev Container (Node **22**, pnpm, zsh) aligned with CI and `package.json`.
+This repository includes a Dev Container (Node **22**, pnpm) aligned with CI and `package.json`.
 
 - In VS Code / Cursor: **Reopen in Container**. The image builds, then `pnpm install` runs.
 - Port **3333** is forwarded for the Mintlify preview.
 - Mint comes from the project (`pnpm install`), not a global CLI baked into the image.
 
-Inside the container:
+Start the preview with:
 
 ```bash
-mintdev
+pnpm dev
 ```
-
-That runs `pnpm dev` (Mintlify on port 3333) with file-watch polling enabled.
 
 Dev Containers are optional; useful for a consistent environment without managing Node or pnpm locally.


### PR DESCRIPTION
## Summary
- Bump Dev Container Node image from **20** → **22** (matches `engines` + CI).
- Stop installing global `mint@latest`; use project Mint via `pnpm install` / `pnpm dev`.
- `postCreateCommand` is install-only (no blocking `mint dev`); forward port **3333**.
- Drop zsh / oh-my-zsh / `mintdev` alias — default shell + plain `pnpm dev`.
- Trim unused extensions (ESLint, Nuxt MDC, mintlify.document); sync README.

## Test plan
- [ ] Reopen in Container builds on Node 22
- [ ] `pnpm install` completes in postCreate
- [ ] `pnpm dev` serves preview on forwarded 3333
- [ ] `node -v` is v22.x; `pnpm exec mint --version` matches lockfile mint