### PR TITLE
Document the Plant 3D connector

### DIFF
--- a/connectors/plant3d.mdx
+++ b/connectors/plant3d.mdx
@@ -1,0 +1,89 @@
+---
+title: How to use Speckle for Plant 3D
+sidebarTitle: Plant 3D
+description: 'Step-by-step guide for publishing Plant 3D models to Speckle'
+---
+
+import Versions from '/snippets/versions.mdx'
+import Setup from '/snippets/connectors/setup.mdx'
+import SetupFaq from '/snippets/connectors/setup-faq.mdx'
+import Login from '/snippets/connectors/login.mdx'
+import PublishOnly from '/snippets/connectors/publish-only-connectors.mdx'
+import PublishFaq from '/snippets/connectors/publish-faq.mdx'
+import NoLoad from '/snippets/connectors/no-load.mdx'
+
+<Versions app="Plant 3D" versions="2026 & 2027" os="Windows" />
+
+## Setup
+
+<Steps>
+  <Setup app="Plant 3D" />
+
+  <Step title="Open the Plant 3D connector">
+    1. In Plant 3D, select the **Speckle** tab in the ribbon.
+    2. Select **Speckle** to open the Plant 3D connector.
+    <Login app="Plant 3D" />
+  </Step>
+</Steps>
+
+<AccordionGroup>
+  <SetupFaq app="Plant 3D" />
+</AccordionGroup>
+
+## Publishing a Model
+
+<PublishOnly app="Plant 3D" />
+
+<AccordionGroup>
+
+  <Accordion title="What types of Plant 3D objects can I publish to Speckle?">
+    You can publish Plant 3D objects such as:
+
+    - pipes
+    - inline assets, including fittings and valves
+    - equipment
+    - P&ID objects, including assets and line segments
+
+    You can also publish supported AutoCAD drawing entities, including lines, curves, text, hatches,
+    solids, meshes, and blocks. Plant 3D objects without a dedicated conversion are published using
+    their available display geometry when possible.
+  </Accordion>
+
+  <Accordion title="Which Plant 3D properties are published?">
+    Objects linked to the Plant 3D project database include their available project data, such as
+    tags, nominal dimensions, and other fields associated with the object. These fields are grouped
+    under `P&ID` in the object's properties in Speckle.
+
+    Extension dictionary and other available object properties are also included. The exact fields
+    depend on the object's class and the data defined in your Plant 3D project.
+  </Accordion>
+
+  <Accordion title="How is Plant 3D geometry represented in Speckle?">
+    Plant 3D objects are published with display geometry that can be viewed in Speckle. Composite
+    objects are broken down into supported geometric parts while remaining a single selectable
+    object with their Plant 3D properties attached.
+  </Accordion>
+
+  <Accordion title="How are published objects organized?">
+    Published objects are organized by their Plant 3D drawing layers. Their original layer, color,
+    and material information is included when available.
+  </Accordion>
+
+  <Accordion title="Why are some Plant 3D objects missing geometry?">
+    The connector uses the display geometry available from Plant 3D. An object may publish without
+    geometry if Plant 3D cannot provide geometry that the connector can convert. Its available
+    properties may still be published.
+  </Accordion>
+
+  <Accordion title="Why is my new model name pre-filled?">
+    New model creation defaults to your current drawing's file name. You can edit the model name
+    before publishing.
+  </Accordion>
+
+  <PublishFaq app="Plant 3D" />
+
+</AccordionGroup>
+
+## Loading a Model
+
+<NoLoad app="Plant 3D" />

--- a/connectors/plant3d.mdx
+++ b/connectors/plant3d.mdx
@@ -47,6 +47,7 @@ import NoLoad from '/snippets/connectors/no-load.mdx'
     You can also publish supported AutoCAD drawing entities, including lines, curves, text, hatches,
     solids, meshes, and blocks. Plant 3D objects without a dedicated conversion are published using
     their available display geometry when possible.
+
   </Accordion>
 
   <Accordion title="Which Plant 3D properties are published?">
@@ -56,31 +57,32 @@ import NoLoad from '/snippets/connectors/no-load.mdx'
 
     Extension dictionary and other available object properties are also included. The exact fields
     depend on the object's class and the data defined in your Plant 3D project.
+
   </Accordion>
 
-  <Accordion title="How is Plant 3D geometry represented in Speckle?">
-    Plant 3D objects are published with display geometry that can be viewed in Speckle. Composite
-    objects are broken down into supported geometric parts while remaining a single selectable
-    object with their Plant 3D properties attached.
-  </Accordion>
+<Accordion title="How is Plant 3D geometry represented in Speckle?">
+  Plant 3D objects are published with display geometry that can be viewed in Speckle. Composite
+  objects are broken down into supported geometric parts while remaining a single selectable object
+  with their Plant 3D properties attached.
+</Accordion>
 
-  <Accordion title="How are published objects organized?">
-    Published objects are organized by their Plant 3D drawing layers. Their original layer, color,
-    and material information is included when available.
-  </Accordion>
+<Accordion title="How are published objects organized?">
+  Published objects are organized by their Plant 3D drawing layers. Their original layer, color, and
+  material information is included when available.
+</Accordion>
 
-  <Accordion title="Why are some Plant 3D objects missing geometry?">
-    The connector uses the display geometry available from Plant 3D. An object may publish without
-    geometry if Plant 3D cannot provide geometry that the connector can convert. Its available
-    properties may still be published.
-  </Accordion>
+<Accordion title="Why are some Plant 3D objects missing geometry?">
+  The connector uses the display geometry available from Plant 3D. An object may publish without
+  geometry if Plant 3D cannot provide geometry that the connector can convert. Its available
+  properties may still be published.
+</Accordion>
 
-  <Accordion title="Why is my new model name pre-filled?">
-    New model creation defaults to your current drawing's file name. You can edit the model name
-    before publishing.
-  </Accordion>
+<Accordion title="Why is my new model name pre-filled?">
+  New model creation defaults to your current drawing's file name. You can edit the model name
+  before publishing.
+</Accordion>
 
-  <PublishFaq app="Plant 3D" />
+<PublishFaq app="Plant 3D" />
 
 </AccordionGroup>
 

--- a/docs.json
+++ b/docs.json
@@ -492,6 +492,7 @@
                   "connectors/navisworks",
                   "connectors/blender",
                   "connectors/civil3d",
+                  "connectors/plant3d",
                   "connectors/autocad",
                   "connectors/etabs",
                   "connectors/teklastructures",


### PR DESCRIPTION
## What changed

- add a Plant 3D connector guide following the existing connector-page structure
- document supported Plant 3D versions, publishing workflow, supported objects, project properties, geometry behavior, and limitations
- add Plant 3D to the connector navigation

## Why

The Plant 3D connector is available but did not have a user-facing documentation page.