### PR TITLE
Enhances data validation docs and introduces sweep skill

### DIFF
--- a/.universal-ai-config/instructions/docs-general.md
+++ b/.universal-ai-config/instructions/docs-general.md
@@ -14,6 +14,9 @@ alwaysApply: true
 - User intent over system architecture.
 - Progressive disclosure: simple first, depth later.
 - Document what exists today.
+- When UI labels, operators, plan gates, or enums look stale, verify against the
+  product (FE3 / shared packages) before rewriting. For multi-page parity audits,
+  use the **docs-product-capability-sweep** skill—not memory of older product names.
 
 ## Quality Bar
 

--- a/.universal-ai-config/skills/docs-product-capability-sweep/SKILL.md
+++ b/.universal-ai-config/skills/docs-product-capability-sweep/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: docs-product-capability-sweep
+description: >-
+  Audit and update existing Speckle product docs against FE3 (or other product)
+  source of truth. Use when docs look stale, UI labels or operators drifted,
+  user asks for a capability sweep / parity pass / gap inventory, or when
+  expanding thin reference sections from real product behavior—not for
+  greenfield feature docs (use document-dev-speckle-feature) or CI-only fixes
+  (use docs-ci-ready).
+argumentHint: '[product area or docs path, e.g. analytics/data-validation]'
+---
+
+# Docs product capability sweep
+
+Align **existing** Mintlify pages under this docs package with what the product
+does today. Scope is any product area (Data Validation, Dashboards, Workspaces,
+viewer, connectors, …)—not one feature family.
+
+Work only under **`speckle-docs-NEW/`** for creates/edits. Treat sibling trees
+(e.g. `Server/`) as **read-only** evidence unless the user explicitly asks to
+edit them.
+
+Do **not** edit the plan file if one is attached; implement from the agreed plan.
+
+## When to use / not use
+
+**Use when:** stale UI labels, incomplete operator/enum catalogs, wrong plan
+gates, thin “predicates / filters / settings” sections, or “full capability
+sweep” of an existing doc group.
+
+**Do not use when:** documenting a brand-new feature from scratch →
+`document-dev-speckle-feature`. CI format/validate only → `docs-ci-ready`.
+Classic frozen forks → workspace `fe3-docs-classic-allowlist` (allowlist only).
+
+## 1. Lock scope with the user
+
+If `$ARGUMENTS` names an area, start there. Otherwise ask briefly:
+
+1. **Depth** — catalog/reference only vs multi-page capability sweep
+2. **Examples** — short inline examples (default) vs cookbook
+3. **New page?** — prefer expanding existing pages; new nav page only if the
+   reference would dominate a workflow page
+
+Default if user shrugs: multi-page sweep, short examples, no new page.
+
+## 2. Map source of truth (read-only)
+
+Find product truth before rewriting prose:
+
+| Kind | Where to look |
+| ---- | ------------- |
+| UI labels / operators | FE3 components (dropdowns, `opOptions`, copy) |
+| Semantics | Shared packages (`eav-queries`, filtering helpers, GraphQL) |
+| Plan / edit limits | Upgrade dialogs, save flows, “Coming soon” panels |
+| Scoring / severity | Result composables, displayConfig |
+
+Prefer UI-facing labels in docs. Do not invent type-filtered dropdowns or ops
+the UI does not expose. Skip internal-only ops unless the user asks.
+
+Do **not** paste product-specific catalogs into this skill—always re-discover.
+
+## 3. Gap inventory (before edits)
+
+Read the live nav group in `docs.json` and every page in scope. Produce a short
+inventory:
+
+- Per page: covered / thin / wrong / missing
+- Cross-page duplication
+- Recommended **page ownership** (which page owns the canonical reference)
+
+Share inventory + ownership; get plan approval for large sweeps. Small
+single-section fixes can proceed after stating intent.
+
+## 4. Edit with ownership
+
+| Page role | Owns | Does not own |
+| --------- | ---- | ------------ |
+| Overview / intro | Concepts, plan caps, entry points, deep links | Full catalogs |
+| Authoring / how-to | Workflows, operators/settings reference, limits | Result triage UI |
+| Templates / import | Import fidelity, spawn/reuse flows | Operator catalog (link out) |
+| Results / review | Surfaces, drill, export, PENDING | How to author rules |
+
+Authoring rules: follow `docs-authoring`, `docs-steps`, `docs-faqs`, `docs-asides`.
+Honest limitations. Progressive disclosure. Cross-link instead of copying.
+
+## 5. Verify
+
+From this package root:
+
+```bash
+pnpm valid
+pnpm exec prettier --write <changed.mdx>
+```
+
+Before PR: invoke **`docs-ci-ready`**.
+
+## Anti-patterns
+
+- Rewriting from memory of an older product name or enum set
+- Duplicating the same catalog on every sibling page
+- Documenting dashboard widget enums as FE3 Data Validation (or vice versa)
+  without checking both SoTs
+- Expanding Classic docs for FE3 parity

--- a/analytics/data-validation/checks.mdx
+++ b/analytics/data-validation/checks.mdx
@@ -7,8 +7,9 @@ description: 'Author and run Validation Checks with WHERE/CHECK logic in Data Va
 <Warning>
   Current limitation:
 
-In v0, after creation you can rename a check only; scope, rule list, and predicates stay
-frozen. For different behaviour, create a new check.
+After you save a check, you can edit its name and description, or delete it. Tracked
+models, rules, predicates, and trigger mode stay frozen. For different behaviour, create a
+new check.
 
 </Warning>
 
@@ -20,13 +21,12 @@ Use this page for **Validation Check** authoring and execution.
 </Info>
 
 <Note>
-  v0 release behavior (available today):
-  checks can be defined and run against all models in a project. Editing an existing
-  check is currently limited to its name; scope and rules are not yet editable after
-  creation.
+  Checks can be defined and run against models in a project (plan caps apply). Editing an
+  existing check is limited to name and description until model scope, rules, and trigger
+  mode become editable.
 
-This will evolve. We would value feedback on the expected **versioning behavior** for
-checks (for example: mutable checks vs immutable versions/forks).
+Feedback welcome on expected **versioning behavior** for checks (for example: mutable
+checks vs immutable versions or forks).
 
 </Note>
 

--- a/analytics/data-validation/checks.mdx
+++ b/analytics/data-validation/checks.mdx
@@ -85,16 +85,16 @@ First visit to results can lag when many rules, models, or deep history enqueue 
 
 Each rule is filters plus one assertion.
 
-| Component       | Description                                                                 |
-| --------------- | --------------------------------------------------------------------------- |
-| `WHERE`         | Filter scope of objects evaluated by the rule                               |
-| `AND`           | Optional additional filters within the same scope                           |
-| `CHECK`         | Final validation assertion                                                  |
-| Property path   | Target property (`category`, `baseline.length`, `parameters.Width.value`)   |
-| Predicate       | Comparison operator (**Equals**, **Exists**, **Matches pattern**, and more) |
-| Value           | Reference value for the predicate                                           |
-| Report severity | `ERROR` or `INFO`                                                           |
-| Message         | Human-facing explanation for failed outcomes                                |
+| Component       | Description                                                                   |
+| --------------- | ----------------------------------------------------------------------------- |
+| `WHERE`         | Filter scope of objects evaluated by the rule                                 |
+| `AND`           | Optional additional filters within the same scope                             |
+| `CHECK`         | Final validation assertion                                                    |
+| Property path   | Target property (`category`, `baseline.length`, `parameters.Width.value`)     |
+| Predicate       | Comparison operator (see [Predicates and matching](#predicates-and-matching)) |
+| Value           | Reference value for the predicate                                             |
+| Report severity | `error` or `info` (`info` does not drive the overall check score)             |
+| Message         | Human-facing explanation for failed outcomes                                  |
 
 ## Default scope
 
@@ -106,7 +106,8 @@ objects match it. Narrow with category/type/parameters—dropping `DataObject` w
 
 ## Thresholds and status
 
-Rates map through thresholds:
+Rates map through thresholds. You set a global pass (and optional warn) threshold when saving,
+and you can override thresholds per rule in authoring.
 
 | Setting           | Effect                                                      |
 | ----------------- | ----------------------------------------------------------- |

--- a/analytics/data-validation/checks.mdx
+++ b/analytics/data-validation/checks.mdx
@@ -203,15 +203,15 @@ Run preview before save so you catch false positives before history is recorded.
     Yes—pick models and triggers after choosing the standard as the base.
   </Accordion>
   <Accordion title="How do I know a check is too strict?">
-    Noise usually means tighten `WHERE`, tune predicates, or downgrade severity.
+    Noise usually means tighten `WHERE`, tune predicates, or downgrade severity to `info`.
   </Accordion>
   <Accordion title="What happens to check results when a tracked model is deleted?">
     Existing results stay in history because they store the evaluated model/version ids from run
     time. The deleted model no longer appears in live scope, so future runs exclude it.
   </Accordion>
   <Accordion title="Can rules inside one check be reordered?">
-    Rule order follows how rules were authored and saved. Reordering is not supported in v0, so
-    duplicate/delete is the fallback when order matters for review.
+    Rule order follows how rules were authored and saved. Reordering is not supported yet, so
+    duplicate or recreate is the fallback when order matters for review.
   </Accordion>
   <Accordion title="What is the difference between preview and saving a check?">
     Preview runs against the current session model/version and is not persisted after you leave.
@@ -219,8 +219,7 @@ Run preview before save so you catch false positives before history is recorded.
   </Accordion>
   <Accordion title="How do I recover when a version update spikes unexpected failures?">
     First confirm the result used the model/version you expected, then inspect failing rules for
-    missing or changed properties in the new version. If needed, duplicate the check for debug
-    narrowing, export BCF for issue handoff, then create a replacement check once root cause is
-    clear.
+    missing or changed properties in the new version. If needed, create a narrower replacement check
+    for debug, export BCF for issue handoff, then keep the replacement once root cause is clear.
   </Accordion>
 </AccordionGroup>

--- a/analytics/data-validation/checks.mdx
+++ b/analytics/data-validation/checks.mdx
@@ -117,15 +117,75 @@ Rates map through thresholds:
 Statuses: **`PASS`** (≥ pass), **`WARN`** (between thresholds when warn is set), **`FAIL`**
 (under thresholds), **`PENDING`** (evaluation not finished).
 
+Only **`error`** severity rules contribute to the overall check score. **`info`** rules still
+evaluate and appear in results, but they do not change the aggregate pass rate.
+
+Interpret outcomes on [Viewing Results](/analytics/data-validation/viewing-results).
+
 ## Predicates and matching
 
-Type-aware predicates:
+The operator dropdown lists every authorable predicate. The UI does not grey operators by
+property type—pick a value shape that matches the property you are testing (text, number, or
+boolean). Booleans compare as Equals with `true` or `false`.
 
-- Text: **Exists**, **Equals**, **Contains**, **Matches pattern**
-- Number: **Is greater than**, **Is less than**, **Is between**
-- Boolean: **Is true**, **Is false**
+### Operator catalog
 
-**Matches pattern** accepts wildcard or regex-like syntax per field help.
+| Operator        | Typical value                      | Behaviour                                                           |
+| --------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| Equals          | text, number, or boolean           | Exact equality on the property value                                |
+| Equals property | another property path              | Path-to-path equality                                               |
+| Equals template | template with `{{token}}` bindings | Build expected text from other paths; exact or regex mode           |
+| Not equals      | text, number, or boolean           | Value must differ                                                   |
+| Greater than    | number                             | Strict `>`                                                          |
+| At least        | number                             | `≥` (tolerance can widen the lower bound)                           |
+| Less than       | number                             | Strict `<`                                                          |
+| At most         | number                             | `≤` (tolerance can widen the upper bound)                           |
+| In list         | one or more text or number values  | Value must be one of the listed items                               |
+| Between         | min and max numbers                | Inclusive range (`≥ min` and `≤ max`)                               |
+| Contains        | text substring                     | Substring match (wildcards in the needle are literal, not patterns) |
+| Matches         | wildcard or regex pattern          | Wildcard by default; toggle `.*` for regex (see below)              |
+| Exists          | _(none)_                           | Property path is present on the object                              |
+
+### Matching details
+
+**Matches (wildcard):** `*` and `%` match any character run; `?` matches one character.
+Matching is case-sensitive.
+
+**Matches (regex):** turn on the `.*` toggle to use a regular expression. You can enter a
+plain pattern, or a `/pattern/i` literal for case-insensitive matching. Lookahead,
+lookbehind, and backreferences are not supported.
+
+**Equals template:** bind `{{token}}` placeholders to other property paths. Use exact mode
+to require the concatenated value, or regex mode (same `.*` toggle) when the template is a
+pattern.
+
+**Contains** is substring search only. Prefer **Matches** when you need wildcards or regex.
+
+### Numeric tolerance
+
+Optional per-condition **Tolerance** sets decimal places `N` (ε = 10^-N). It applies to
+numeric **Equals**, **Equals property**, **At least**, **At most**, and **Between**. It
+does not apply to **Greater than**, **Less than**, **Not equals**, list/text operators, or
+**Exists**.
+
+### Property paths
+
+Pick paths from the path picker after a preview model loads so value suggestions come from
+real data. Common shapes:
+
+- `category`
+- `name`
+- `baseline.length`
+- `parameters.Width.value`
+
+### Short examples
+
+- Fire rating present: `WHERE` category Equals `Walls`, `CHECK` fire-rating path **Exists**
+  (or **Equals** a required rating string).
+- Width band: `CHECK` `parameters.Width.value` **Between** `100` and `300`, with tolerance if
+  units are noisy.
+- Naming convention: `CHECK` `name` **Matches** `W-*` (or **Contains** a fixed prefix).
+- Consistency: `CHECK` one path **Equals property** against another path on the same object.
 
 ## Best practices
 

--- a/analytics/data-validation/overview.mdx
+++ b/analytics/data-validation/overview.mdx
@@ -56,7 +56,8 @@ You need at least one published model version in the project.
 
 ### After the first pass
 
-For authoring details and run analysis, see [Checks](/analytics/data-validation/checks),
+For authoring details and run analysis, see [Checks](/analytics/data-validation/checks)
+(including [predicates and matching](/analytics/data-validation/checks#predicates-and-matching)),
 [Standards](/analytics/data-validation/standards), and
 [Viewing Results](/analytics/data-validation/viewing-results).
 
@@ -69,7 +70,7 @@ In the project sidebar:
 
 - **Data Validation**
 - **Run check** — draft / preview without persisting yet
-- **Checks** — saved checks (rename only in v0; see Checks page)
+- **Checks** — saved checks (name and description editable; rules and scope frozen—see Checks)
 - **Project standards** — create / import standards
 
 ## Progressive implementation sequence
@@ -88,7 +89,7 @@ flow](/analytics/data-validation/standards#standards-to-checks-flow)).
 
 <CardGroup cols={2}>
   <Card title="Run and manage checks" icon="play" href="/analytics/data-validation/checks">
-    Rules, preview, thresholds, saves, tracked models.
+    Rules, predicates, preview, thresholds, saves, tracked models.
   </Card>
   <Card
     title="Create project standards"
@@ -119,7 +120,7 @@ flow](/analytics/data-validation/standards#standards-to-checks-flow)).
 Caps differ mainly on whether checks persist and whether multiple models attach per check.
 
 <AccordionGroup>
-  <Accordion title="What Model Validation (beta) features do I get on each plan?">
+  <Accordion title="What Data Validation features do I get on each plan?">
     **Explore (Free):** in-session authoring and preview only; no saved checks or preserved
     history.
 

--- a/analytics/data-validation/standards.mdx
+++ b/analytics/data-validation/standards.mdx
@@ -43,22 +43,33 @@ one mandate per rule, per-rule preview, duplicate shared filters.
 
 ## Import formats
 
-**IDS:** IFC-aligned facets import into standard rules, then open in the same editor for
-preview and adjustment. Some advanced applicability/property mappings may need manual fixes before
-use in checks.
+Imports land under **Project standards** with no extra publish step. Always rerun preview on
+a representative revision after import, then tune predicates if needed—see
+[Predicates and matching](/analytics/data-validation/checks#predicates-and-matching).
 
-**COBie:** Worksheet fields map into rules and are saved under project standards after import.
-Unusual columns or macro-heavy sheets can lose fidelity, so verify property paths, severities, and
-messages before spawning checks.
+### IDS
 
-**Speckle:** JSON/tab exports from dashboards, Automate, or related tooling import directly as
-standards entries. Rows with widget-specific semantics may still need rewrite into explicit
-`WHERE` / `CHECK` logic.
+IFC-aligned facets import into standard rules, then open in the same editor for preview and
+adjustment. Most facets map to **Exists**, **Equals**, **In list**, or **Between**. IDS
+`xs:pattern` values often land as **Contains** rather than full regex—verify naming rules
+after import. Advanced applicability or property mappings may need manual fixes before you
+spawn checks.
 
-New rows appear instantly in **Project standards**—no extra publish step.
+### COBie
 
-Regardless of vendor, rerun preview on a representative revision to catch importer blind
-spots.
+Worksheet fields map into rules under project standards after import. Typical outcomes are
+sheet-scoped **Exists** checks and pick-list **In list** assertions. Optional fields often
+arrive as **`info`** severity so they do not drive the overall score. Unusual columns or
+macro-heavy sheets can lose fidelity—verify property paths, severities, and messages before
+spawning checks.
+
+### Speckle
+
+JSON, TSV, or CSV exports from dashboards and related tooling import as standards entries.
+Supported dashboards predicates map into Data Validation operators; unsupported negation
+conditions (for example not exists, not in list, does not contain) are skipped. Dashboard
+**warning** severity is coerced to **`info`**. Rows with widget-specific semantics may still
+need rewrite into explicit `WHERE` / `CHECK` logic.
 
 ## Standards to checks flow
 

--- a/analytics/data-validation/viewing-results.mdx
+++ b/analytics/data-validation/viewing-results.mdx
@@ -4,11 +4,9 @@ sidebarTitle: 'Viewing Results'
 description: 'Interpret latest and historical Data Validation outcomes, including status badges and trend context.'
 ---
 
-## In Intelligence Dashboards
-
 <Info>
-  This page covers **Data Validation (checks and standards)** detail and history views. For
-  **dashboard-based validation widget** result reading, see [Validation Widgets in
+  This page covers **Data Validation** check detail and history views. For dashboard-based
+  validation widget results, see [Validation Widgets in
   Dashboards](/analytics/dashboards/validation-widgets).
 </Info>
 
@@ -23,34 +21,41 @@ There are two high-level result views used for quick status checks:
 
 ## Practical review flow
 
-These high-level views are a KPI heads-up layer for rules defined by your team. Use
-them to spot drift quickly, then drill into a specific check for detailed analysis.
+These high-level views are a KPI heads-up layer for rules defined by your team. Use them to
+spot drift quickly, then drill into a specific check for detailed analysis.
 
-When you open a check result page, you will typically see:
+When you open a check result page, you typically see:
 
-## Result states
-
-- a top-level check score and status
+- a top-level check score and status (aggregate across all models in scope)
 - a per-rule list showing pass/warn/fail outcomes
-- expandable rule rows to inspect logic flow (`WHERE` -> `CHECK`) and counts at each step
+- expandable rule rows to inspect logic flow (`WHERE` → `CHECK`) and counts at each step
 - model cards for each model included in the check scope
 - latest run details (time, model/version context)
 - historical trend for previous runs
-- object-level detail table for investigation, including passing and failing objects
+- an object-level detail table for investigation, including passing and failing objects
 
-| Status    | Meaning                                                                                    |
-| --------- | ------------------------------------------------------------------------------------------ |
-| `PASS`    | Pass-rate ≥ configured pass threshold.                                                     |
-| `WARN`    | Between warn/pass band when configured.                                                    |
-| `FAIL`    | Below thresholds.                                                                          |
-| `PENDING` | Evaluation still running in background for that rollup across models, versions, and rules. |
+Selecting **View result** on a model card opens that model’s detailed result, where you can
+inspect the rule-by-rule breakdown, the light 3D viewer, and the data table. Use the table
+and viewer together: selecting failing (or passing) rows focuses the matching objects in the
+viewer for triage.
 
-This top section is the **aggregate result** for the check across all models in scope.
-Selecting **View result** from a model card opens that model’s detailed result, where
-you can inspect rule-by-rule breakdown, the 3D viewer state, and the data table.
-Threshold tuning: [Checks — Thresholds and status](/analytics/data-validation/checks#thresholds-and-status).
+Threshold authoring: [Checks — Thresholds and
+status](/analytics/data-validation/checks#thresholds-and-status).
 
-## If a result looks unexpected, check
+## Result states
+
+| Status    | Meaning                                                                                |
+| --------- | -------------------------------------------------------------------------------------- |
+| `PASS`    | Pass-rate ≥ configured pass threshold.                                                 |
+| `WARN`    | Between warn/pass band when configured.                                                |
+| `FAIL`    | Below thresholds.                                                                      |
+| `PENDING` | Evaluation still running, or no completed rollup exists yet for that rule/run context. |
+
+The top section is the **aggregate result** for the check across all models in scope. Only
+**`error`** severity rules drive the overall score; **`info`** rules still appear in the
+breakdown.
+
+## If a result looks unexpected
 
 <Steps>
   <Step title="Open latest check result">
@@ -68,27 +73,35 @@ Threshold tuning: [Checks — Thresholds and status](/analytics/data-validation/
     If external coordination tooling is used, include BCF export in handoff.
   </Step>
 </Steps>
-1. Same model/version you expected auditing? 2. Predicates/threshold edits since that baseline
-snapshot? 3. Failures clustered by stream or timeframe (data drift) vs sporadic flake?
+
+Before you retune rules, confirm:
+
+1. The result used the model and version you expected.
+2. Predicates or thresholds have not changed since the baseline snapshot (create a new check
+   if you need different behaviour).
+3. Failures cluster by model or timeframe (data drift) versus looking like sporadic noise.
 
 ## Model and version context
 
-Plans cap how many models attach. Every row references explicit version ids plus trigger +
-timestamp—carry that along when debating trends.
+Plans cap how many models attach. Every row references explicit version ids plus trigger and
+timestamp—carry that context when debating trends.
 
 ## Coordination handoff
 
-BCF export from validation emits topic scaffolding plus failures so coordinators triage outside
-Speckle.
+BCF export from a validation result packages failing objects into topics with viewpoints so
+coordinators can triage outside Speckle. Use it when your issue workflow expects BCF; it does
+not replace fixing property data in the authoring tool.
 
 ## FAQ
 
 <AccordionGroup>
   <Accordion title="Why does a rule show PENDING?">
-    `PENDING` appears when no completed evaluation exists yet for that rule/run context.
+    `PENDING` appears when evaluation is still running in the background, or when no completed
+    evaluation exists yet for that rule/run context.
   </Accordion>
   <Accordion title="Can warning thresholds be customized?">
-    Yes. Warning and pass thresholds can be configured globally and per rule in authoring flow.
+    Yes. Warning and pass thresholds can be configured globally and per rule in the authoring flow.
+    See [Thresholds and status](/analytics/data-validation/checks#thresholds-and-status).
   </Accordion>
   <Accordion title="Should I use latest only or history only?">
     Use both. Latest helps with immediate action; history helps with governance and trend


### PR DESCRIPTION
Introduces a new capability sweep skill for auditing product docs, ensuring UI labels stay current. Updates data validation documentation with refined editing capabilities, threshold guidance, and improved predicate descriptions to keep doc parity with real product behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/specklesystems/codesmith/speckle-docs-NEW/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787511317&installation_model_id=3962&pr_number=292&repository=specklesystems%2Fspeckle-docs-NEW&return_to=https%3A%2F%2Fgithub.com%2Fspecklesystems%2Fspeckle-docs-NEW%2Fpull%2F292&signature=af026478a8d417c999d469783ea98605253203994f7d1933e805fc9d638d82c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->