### PR TITLE
enchancement(design-explorer): Morten's Python Hack

### DIFF
--- a/workflows/grasshopper-design-explorer.mdx
+++ b/workflows/grasshopper-design-explorer.mdx
@@ -151,9 +151,9 @@ Click the option name in the header bar to return to the grid.
 
 <AccordionGroup>
   <Accordion title="Why does the widget say 'Design Explorer requires a Grasshopper data source'?">
-    The widget checks the source application of the connected model. Only models published from the
-    Grasshopper connector are supported. Connect a different data source or re-publish the model
-    from Grasshopper.
+    The widget checks the source application of the connected model and expects Grasshopper.
+    Re-publish the model from Grasshopper, or connect a data source that was. If you are producing
+    design options from somewhere else, see [Under the hood](#under-the-hood).
   </Accordion>
   <Accordion title="Why does the widget say 'No design options found'?">
     Check that each Data Object has been marked as a design option via the right-click menu (**Mark

--- a/workflows/grasshopper-design-explorer.mdx
+++ b/workflows/grasshopper-design-explorer.mdx
@@ -171,6 +171,72 @@ Click the option name in the header bar to return to the grid.
   </Accordion>
 </AccordionGroup>
 
+## Under the hood
+
+<AccordionGroup>
+  <Accordion title="What does 'Mark as Design Option' actually do?">
+    Nothing exotic — it writes a property. The menu item sets a boolean at the dotted path
+    `DesignOption.isDesignOption` on the Data Object, which lands on the wire as:
+
+    ```json
+    "properties": {
+      "DesignOption": { "isDesignOption": true },
+      "cost": { "material": 42000 }
+    }
+    ```
+
+    The marker is excluded from the metrics, so it never appears as a chart axis.
+
+    See [`SpeckleDataObjectPassthrough.cs#L208-L213`](https://github.com/specklesystems/speckle-sharp-connectors/blob/dd065202c03a1bade2c720cce1943172389397a6/Connectors/Rhino/Speckle.Connectors.GrasshopperShared/Components/Objects/SpeckleDataObjectPassthrough.cs#L208-L213) (pinned at `dd06520`).
+
+  </Accordion>
+
+  <Accordion title="Can I produce design options from Python or another connector?">
+    Not officially — but nothing about the marker is Grasshopper-specific, and the only thing
+    stopping you is a source-application check on the widget.
+
+    Build the Data Objects with the marker in their properties, then set the version's
+    source application so the widget accepts the model:
+
+    ```python
+    from specklepy.objects.data import DataObject
+    from specklepy.core.api.inputs.version_inputs import CreateVersionInput
+
+    element = DataObject(
+        name="Option A",
+        properties={
+            "DesignOption": {"isDesignOption": True},
+            "cost": {"material": 42000},
+        },
+        displayValue=[geometry],
+    )
+
+    version_input = CreateVersionInput(
+        project_id=project.id,
+        model_id=model_id,
+        object_id=object_id,
+        message="Design study",
+    )
+    version_input.source_application = "grasshopper"
+    ```
+
+    Two things to watch that the Grasshopper component handles for you:
+
+    - The widget isolates the marked object itself, not its children. All geometry for a variant
+      must sit on that object's `displayValue`.
+    - Every marked object needs the same numeric property keys, or the odd ones out are dropped
+      from the chart.
+
+    <Warning>
+      This is unsupported and misreports how the version was produced. It works, but treat it as a
+      hack rather than an integration: the source-application check may be relaxed or replaced, and
+      this workaround will not be preserved deliberately. If you are relying on it, say so on the
+      [forum](https://speckle.community) — a real use case is what would justify supporting design
+      options outside Grasshopper properly.
+    </Warning>
+  </Accordion>
+</AccordionGroup>
+
 ## See also
 
 - [Grasshopper connector](/connectors/grasshopper/grasshopper)

--- a/workflows/grasshopper-design-explorer.mdx
+++ b/workflows/grasshopper-design-explorer.mdx
@@ -234,6 +234,7 @@ Click the option name in the header bar to return to the grid.
       [forum](https://speckle.community) — a real use case is what would justify supporting design
       options outside Grasshopper properly.
     </Warning>
+
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Introduces an 'Under the hood' section for developer insights and refines the explanation of Grasshopper widget data source requirements, clarifying how design options can be marked and recognised.

Related discussion encouraged on the forum for unsupported integrations. https://speckle.community/t/design-explorer-hack/23168