### PR TITLE
Adds BCF export clarification to data validation guide

### DIFF
--- a/developers/api/guides/data-validation-results.mdx
+++ b/developers/api/guides/data-validation-results.mdx
@@ -378,7 +378,7 @@ SPECKLE_TOKEN=your_personal_access_token
 SPECKLE_PROJECT_ID=your_project_id
 ```
 
-**Cell 1 — install dependencies** (notebook only):
+Cell 1 — install dependencies (notebook only):
 
 ```python
 %pip install -q specklepy pandas python-dotenv

--- a/developers/api/guides/data-validation-results.mdx
+++ b/developers/api/guides/data-validation-results.mdx
@@ -758,5 +758,10 @@ After running Step 4:
 
 ## Related documentation
 
-- [GraphQL API](/developers/api/graphql)
-- [Data Validation overview](/analytics/data-validation/overview)
+- [GraphQL API](/developers/api/graphql) — authentication, endpoint, and schema reference
+- [Building with PATs](/developers/authentication/pats) — creating the token this guide uses
+- [SpecklePy](/developers/sdks/python/introduction) — the SDK the Python examples are built on
+- [SpecklePy model data analytics](/workflows/specklepy-model-data-analytics) — related query patterns against model data
+- [Data Validation overview](/analytics/data-validation/overview) — what checks and standards are
+- [Viewing results](/analytics/data-validation/viewing-results) — how the same results read in the web app, including BCF export
+- [Checks — thresholds and status](/analytics/data-validation/checks#thresholds-and-status) — where the thresholds you read here are set

--- a/developers/api/guides/data-validation-results.mdx
+++ b/developers/api/guides/data-validation-results.mdx
@@ -751,8 +751,18 @@ After running Step 4:
   the full schema, including `projectInsights`, `insight`, and related fields.
 </Accordion>
 
+<Accordion title="How do I retrieve the BCF export of a result?">
+  BCF export is produced from the results view in the web app and has no API route. The GraphQL
+  queries on this page return the same pass, fail, and per-rule data in a form you can write out
+  yourself. For the UI export path, see [Viewing results — coordination
+  handoff](/analytics/data-validation/viewing-results#coordination-handoff).
+</Accordion>
+
   <Accordion title="What is not covered in this guide?">
-    Creating or updating checks (`insightMutations.create`, `update`, `delete`). Ad-hoc validation without saving (`executeQuery`, `executeVersionQuery`). Webhooks or subscriptions when a result is ready (poll instead). REST endpoints for validation results. Authoring EAV query or rule DSL from scratch. Linking validation failures to Speckle issues (`syncValidationIssues`). Retrieving the BCF export of a result — BCF is produced from the results view in the web app and has no API route; the queries here return the same pass, fail and per-rule data in a form you can write out yourself.
+    Creating or updating checks (`insightMutations.create`, `update`, `delete`). Ad-hoc validation
+    without saving (`executeQuery`, `executeVersionQuery`). Webhooks or subscriptions when a result
+    is ready (poll instead). REST endpoints for validation results. Authoring EAV query or rule DSL
+    from scratch. Linking validation failures to Speckle issues (`syncValidationIssues`).
   </Accordion>
 </AccordionGroup>
 

--- a/developers/api/guides/data-validation-results.mdx
+++ b/developers/api/guides/data-validation-results.mdx
@@ -739,8 +739,8 @@ After running Step 4:
   Copy the [Step 4](#step-4-build-a-kpi-dataframe) cells into your own Jupyter project, or [download
   the
   notebook](https://raw.githubusercontent.com/specklesystems/speckle-docs-new/refs/heads/main/developers/api/guides/notebooks/data-validation-results.ipynb)
-  from GitHub. Authenticate a `SpeckleClient` with `authenticate_with_token`, wrap each
-  `authenticate_with_token`, wrap each operation in `gql()`, then call
+  from GitHub. Authenticate a `SpeckleClient` with `authenticate_with_token`, wrap each operation in
+  `gql()`, then call
   [`execute_query`](/developers/sdks/python/api-reference/client#custom-graphql-queries) or pass
   `variable_values` to the same authenticated GraphQL client when the operation declares variables.
 </Accordion>

--- a/developers/api/guides/data-validation-results.mdx
+++ b/developers/api/guides/data-validation-results.mdx
@@ -752,7 +752,7 @@ After running Step 4:
 </Accordion>
 
   <Accordion title="What is not covered in this guide?">
-    Creating or updating checks (`insightMutations.create`, `update`, `delete`). Ad-hoc validation without saving (`executeQuery`, `executeVersionQuery`). Webhooks or subscriptions when a result is ready (poll instead). REST endpoints for validation results. Authoring EAV query or rule DSL from scratch. Linking validation failures to Speckle issues (`syncValidationIssues`).
+    Creating or updating checks (`insightMutations.create`, `update`, `delete`). Ad-hoc validation without saving (`executeQuery`, `executeVersionQuery`). Webhooks or subscriptions when a result is ready (poll instead). REST endpoints for validation results. Authoring EAV query or rule DSL from scratch. Linking validation failures to Speckle issues (`syncValidationIssues`). Retrieving the BCF export of a result — BCF is produced from the results view in the web app and has no API route; the queries here return the same pass, fail and per-rule data in a form you can write out yourself.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Incorporates a section explaining the BCF export availability, noting it is not accessible via API and directing users to relevant UI export paths.

Clarifies content to improve user guidance and documentation accuracy.